### PR TITLE
Replace symlinks with a bash script that execs the target

### DIFF
--- a/comm-central/find-repo-files
+++ b/comm-central/find-repo-files
@@ -1,1 +1,3 @@
-../find-repo-files.py
+#!/usr/bin/env bash
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/mozilla-central/find-repo-files
+++ b/mozilla-central/find-repo-files
@@ -1,1 +1,3 @@
-../find-repo-files.py
+#!/usr/bin/env bash
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/nss/find-repo-files
+++ b/nss/find-repo-files
@@ -1,1 +1,3 @@
-../find-repo-files.py
+#!/usr/bin/env bash
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/whatwg-html/find-repo-files
+++ b/whatwg-html/find-repo-files
@@ -1,1 +1,3 @@
-../find-repo-files.py
+#!/usr/bin/env bash
+
+exec $(dirname $0)/../find-repo-files.py $*


### PR DESCRIPTION
This makes the behaviour more predictable on Windows, where symlinks may not
be handled properly.

Similar to https://github.com/mozsearch/mozsearch/pull/65 (but no dependency; the PRs can be merged independently).