### PR TITLE
Allow job types of build-linux64/debug as valid c-c target jobs.

### DIFF
--- a/comm-central/find-mc-rev.py
+++ b/comm-central/find-mc-rev.py
@@ -13,10 +13,11 @@ for resultset in resultsets:
     jobs = client.get_jobs('comm-central',
                            result_set_id=resultset['id'],
                            platform='linux64',
-                           job_type_name='Build',
                            platform_option='debug')
     for job in jobs:
         if job['platform_option'] != 'debug':
+            continue
+        if job['job_type_name'] not in ['build-linux64/debug', 'Build']:
             continue
 
         # We allow 'testfailed' since comm-central builds run some


### PR DESCRIPTION
Apparently at some point recently the job type of linux64 debug builds on c-c changed. This updates the script to allow either the old or the new job type.

(This fixes the problem for me locally but I haven't tested a deployment with it yet)