### PR TITLE
Don't redownload massive tarballs if there are already local copies

### DIFF
--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -7,18 +7,28 @@ date
 
 echo Downloading Gecko
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-dev.tar
-tar xf gecko-dev.tar
-rm gecko-dev.tar
+if [ -d "gecko-dev" ]
+then
+    echo "Found pre-existing gecko-dev folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-dev.tar
+    tar xf gecko-dev.tar
+    rm gecko-dev.tar
+fi
 popd
 
 date
 
 echo Downloading Gecko blame
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-blame.tar
-tar xf gecko-blame.tar
-rm gecko-blame.tar
+if [ -d "gecko-blame" ]
+then
+    echo "Found existing gecko-blame folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-blame.tar
+    tar xf gecko-blame.tar
+    rm gecko-blame.tar
+fi
 popd
 
 date


### PR DESCRIPTION
This makes it a little cheaper to run indexer-setup locally if you've
already run it once. The gecko-dev and gecko-blame tarballs are multiple
gigabytes now.

This goes with mozsearch/mozsearch#92. Note that if you run the indexer-setup script without KEEP_WORKING=1 it will blow away these folders anyway, so this patch really only makes a difference if you are running with KEEP_WORKING=1 and shouldn't affect default behaviour.