### PR TITLE
Mention Rust indexing in help page

### DIFF
--- a/help.html
+++ b/help.html
@@ -11,7 +11,7 @@
 
 <p>
 Searchfox is a source code indexing tool for Mozilla Firefox. It
-indexes C++ and JavaScript code. This is the help page for Searchfox.
+indexes C++, Rust, and JavaScript code. This is the help page for Searchfox.
 
 You can contribute to Searchfox! Visit
 our <a href="https://github.com/mozsearch/mozsearch">Github page</a>.


### PR DESCRIPTION
There's a similar snippet in [a test file in the mozsearch repository](https://github.com/mozsearch/mozsearch/blob/master/tests/help.html). Should it be updated as well?