### PR TITLE
Export the Rust libstd source to the objdir.

### DIFF
--- a/mozilla-central/build
+++ b/mozilla-central/build
@@ -24,4 +24,6 @@ cd $FILES_ROOT
 MOZCONFIG=$INDEX_ROOT/mozconfig ./mach build
 cd -
 
+$MOZSEARCH_PATH/scripts/export-rust-source.sh $OBJDIR
+
 date


### PR DESCRIPTION
This is the required change for https://github.com/mozsearch/mozsearch/pull/123
to work on mozilla-central.