### PR TITLE
Revert "https://api.pub.build.mozilla.org/mapper -> https://mapper.mo…

### DIFF
--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -35,7 +35,7 @@ date
 
 echo Downloading git to hg map
 pushd $INDEX_ROOT
-wget -q https://mapper.mozilla-releng.net/gecko-dev/mapfile/full
+wget -q https://api.pub.build.mozilla.org/mapper/gecko-dev/mapfile/full
 mv full git_hg.map
 popd
 

--- a/nss/setup
+++ b/nss/setup
@@ -34,7 +34,7 @@ date
 
 echo Downloading git to hg map
 pushd $INDEX_ROOT
-wget -q https://mapper.mozilla-releng.net/nss/mapfile/full
+wget -q https://api.pub.build.mozilla.org/mapper/nss/mapfile/full
 mv full git_hg.map
 popd
 


### PR DESCRIPTION
…zilla-releng.net"

This reverts commit 03e66981f8ad33497227e46590f1725c943e3102, as the new gecko-dev URL returns a 503 error.