### PR TITLE
Avoid redownload of nss and whatwg tarballs

### DIFF
--- a/nss/setup
+++ b/nss/setup
@@ -7,27 +7,42 @@ date
 
 echo Downloading NSPR
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-nspr.tar
-tar xf nss-nspr.tar
-rm nss-nspr.tar
+if [ -d "nspr" ]
+then
+    echo "Found pre-existing nspr folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-nspr.tar
+    tar xf nss-nspr.tar
+    rm nss-nspr.tar
+fi
 popd
 
 date
 
 echo Downloading NSS
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-git.tar
-tar xf nss-git.tar
-rm nss-git.tar
+if [ -d "git" ]
+then
+    echo "Found pre-existing git folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-git.tar
+    tar xf nss-git.tar
+    rm nss-git.tar
+fi
 popd
 
 date
 
 echo Downloading NSS blame
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-blame.tar
-tar xf nss-blame.tar
-rm nss-blame.tar
+if [ -d "blame" ]
+then
+    echo "Found pre-existing blame folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-blame.tar
+    tar xf nss-blame.tar
+    rm nss-blame.tar
+fi
 popd
 
 date

--- a/whatwg-html/setup
+++ b/whatwg-html/setup
@@ -7,18 +7,28 @@ date
 
 echo Downloading WHATWG HTML repo
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/whatwg-html-git.tar
-tar xf whatwg-html-git.tar
-rm whatwg-html-git.tar
+if [ -d "html" ]
+then
+    echo "Found pre-existing html folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/whatwg-html-git.tar
+    tar xf whatwg-html-git.tar
+    rm whatwg-html-git.tar
+fi
 popd
 
 date
 
 echo Downloading WHATWG HTML blame
 pushd $INDEX_ROOT
-wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/whatwg-html-blame.tar
-tar xf whatwg-html-blame.tar
-rm whatwg-html-blame.tar
+if [ -d "blame" ]
+then
+    echo "Found pre-existing blame folder; skipping re-download."
+else
+    wget -q https://s3-us-west-2.amazonaws.com/searchfox.repositories/whatwg-html-blame.tar
+    tar xf whatwg-html-blame.tar
+    rm whatwg-html-blame.tar
+fi
 popd
 
 date


### PR DESCRIPTION
The mozilla-central and comm-central repos already have these checks;
for consistency and additional bandwidth davings during local development
we can do it for these repos as well.