### PR TITLE
Re-compress the gecko-dev and gecko-blame repos periodically.

### DIFF
--- a/mozilla-central/upload
+++ b/mozilla-central/upload
@@ -8,6 +8,18 @@ date
 echo Uploading Gecko
 pushd $INDEX_ROOT
 tar cf gecko-dev.tar gecko-dev
+# If the tarball gets bigger than 10GB, re-compress the repo
+TARBALL_SIZE=$(stat -c '%s' gecko-dev.tar)
+TEN_GIGS=$((10 * 1000 * 1000 * 1000))
+if [ $TARBALL_SIZE -gt $TEN_GIGS ]; then
+    git --git-dir=gecko-dev/.git gc
+    tar cf gecko-dev.tar gecko-dev
+    # If it's still bigger than 10GB, spit out a warning
+    TARBALL_SIZE=$(stat -c '%s' gecko-dev.tar)
+    if [ $TARBALL_SIZE -gt $TEN_GIGS ]; then
+        echo "WARNING: gecko-dev.tar is bigger than 10GB even after git gc. Try more aggressive gc, or increase size limit"
+    fi
+fi
 python $AWS_ROOT/upload.py $INDEX_ROOT/gecko-dev.tar searchfox.repositories gecko-dev.tar
 rm gecko-dev.tar
 popd
@@ -17,6 +29,18 @@ date
 echo Uploading Gecko blame
 pushd $INDEX_ROOT
 tar cf gecko-blame.tar gecko-blame
+# If the tarball gets bigger than 5GB, re-compress the repo
+TARBALL_SIZE=$(stat -c '%s' gecko-blame.tar)
+FIVE_GIGS=$((5 * 1000 * 1000 * 1000))
+if [ $TARBALL_SIZE -gt $FIVE_GIGS ]; then
+    git --git-dir=gecko-blame/.git gc
+    tar cf gecko-blame.tar gecko-blame
+    # If it's still bigger than 5GB, spit out a warning
+    TARBALL_SIZE=$(stat -c '%s' gecko-blame.tar)
+    if [ $TARBALL_SIZE -gt $FIVE_GIGS ]; then
+        echo "WARNING: gecko-blame.tar is bigger than 5GB even after git gc. Try more aggressive gc, or increase size limit"
+    fi
+fi
 python $AWS_ROOT/upload.py $INDEX_ROOT/gecko-blame.tar searchfox.repositories gecko-blame.tar
 rm gecko-blame.tar
 popd


### PR DESCRIPTION
Running `git gc` on gecko-dev brought the size down from ~11G
to ~6G and gecko-blame shrunk from ~14G to ~1.7G. This reduces
indexer runtime and data transfer noticeably. This patch
monitors the size of the tarballs and re-compresses the repos
if they get too big.