### PR TITLE
Bug 1490521 - Merge C++ analysis files better

### DIFF
--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -162,7 +162,7 @@ if [ -n "$INDEXED_GIT_REV" ]; then
             if [ ! -f "../analysis/$ANALYSIS_FILE" ]; then
                 move_file "$ANALYSIS_FILE" "../analysis/$ANALYSIS_FILE"
             else
-                cat "$ANALYSIS_FILE" "../analysis/$ANALYSIS_FILE" | sort | uniq > ../analysis.merged
+                $MOZSEARCH_PATH/scripts/merge-analyses.py "$ANALYSIS_FILE" "../analysis/$ANALYSIS_FILE" | sort | uniq > ../analysis.merged
                 mv "../analysis.merged" "../analysis/$ANALYSIS_FILE"
             fi
         done


### PR DESCRIPTION
Use the new analysis-merging script to do the merge, which will
union the symbols properly for source lines.

This depends on https://github.com/mozsearch/mozsearch/pull/145