### PR TITLE
Add a mozilla-releases.json config file

### DIFF
--- a/comm-central/setup
+++ b/comm-central/setup
@@ -42,10 +42,8 @@ if [ -d "mozilla" ]
 then
     echo "Found pre-existing mozilla subfolder; skipping re-download."
 else
-    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-dev.tar
-    tar xf gecko-dev.tar
+    $CONFIG_REPO/shared/fetch-gecko-dev.sh $PWD
     mv gecko-dev mozilla
-    rm gecko-dev.tar
 fi
 
 date

--- a/mozilla-beta/build
+++ b/mozilla-beta/build
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# Don't do anything here. Once bug 1533801 merges to beta
+# we can modify the setup file to pull artifacts from
+# taskcluster to get Rust/C++ data the way we do for mozilla-central.

--- a/mozilla-beta/find-repo-files
+++ b/mozilla-beta/find-repo-files
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/mozilla-beta/setup
+++ b/mozilla-beta/setup
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Downloading Gecko
+pushd $INDEX_ROOT
+if [ -d "gecko-dev" ]
+then
+    echo "Found pre-existing gecko-dev folder; skipping re-download."
+else
+    $CONFIG_REPO/shared/fetch-gecko-dev.sh $PWD
+fi
+popd
+
+date
+
+echo Updating git
+pushd $GIT_ROOT
+git fetch origin
+git checkout -b beta origin/beta
+popd
+
+date

--- a/mozilla-beta/upload
+++ b/mozilla-beta/upload
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# The mozilla-central repo uploads an updated gecko-dev which
+# includes beta commits, so we don't need to do anything here.

--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -12,9 +12,7 @@ if [ -d "gecko-dev" ]
 then
     echo "Found pre-existing gecko-dev folder; skipping re-download."
 else
-    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-dev.tar
-    tar xf gecko-dev.tar
-    rm gecko-dev.tar
+    $CONFIG_REPO/shared/fetch-gecko-dev.sh $PWD
 fi
 popd
 

--- a/mozilla-esr60/build
+++ b/mozilla-esr60/build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# Don't do anything here. It's not likely that we'll
+# want to do Rust/C++ indexing for ESR60, ever.

--- a/mozilla-esr60/find-repo-files
+++ b/mozilla-esr60/find-repo-files
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/mozilla-esr60/setup
+++ b/mozilla-esr60/setup
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Downloading Gecko
+pushd $INDEX_ROOT
+if [ -d "gecko-dev" ]
+then
+    echo "Found pre-existing gecko-dev folder; skipping re-download."
+else
+    $CONFIG_REPO/shared/fetch-gecko-dev.sh $PWD
+fi
+popd
+
+date
+
+echo Updating git
+pushd $GIT_ROOT
+git fetch origin
+git checkout -b esr60 origin/esr60
+popd
+
+date

--- a/mozilla-esr60/upload
+++ b/mozilla-esr60/upload
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# The mozilla-central repo uploads an updated gecko-dev which
+# includes esr60 commits, so we don't need to do anything here.

--- a/mozilla-release/build
+++ b/mozilla-release/build
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# Don't do anything here. Once bug 1533801 merges to release
+# we can modify the setup file to pull artifacts from
+# taskcluster to get Rust/C++ data the way we do for mozilla-central.

--- a/mozilla-release/find-repo-files
+++ b/mozilla-release/find-repo-files
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/mozilla-release/setup
+++ b/mozilla-release/setup
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Downloading Gecko
+pushd $INDEX_ROOT
+if [ -d "gecko-dev" ]
+then
+    echo "Found pre-existing gecko-dev folder; skipping re-download."
+else
+    $CONFIG_REPO/shared/fetch-gecko-dev.sh $PWD
+fi
+popd
+
+date
+
+echo Updating git
+pushd $GIT_ROOT
+git fetch origin
+git checkout -b release origin/release
+popd
+
+date

--- a/mozilla-release/upload
+++ b/mozilla-release/upload
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# The mozilla-central repo uploads an updated gecko-dev which
+# includes release commits, so we don't need to do anything here.

--- a/mozilla-releases.json
+++ b/mozilla-releases.json
@@ -1,0 +1,38 @@
+{
+  "mozsearch_path": "$MOZSEARCH_PATH",
+
+  "trees": {
+    "mozilla-beta": {
+      "index_path": "$WORKING/mozilla-beta",
+      "files_path": "$WORKING/mozilla-beta/gecko-dev",
+      "git_path": "$WORKING/mozilla-beta/gecko-dev",
+      "github_repo": "https://github.com/mozilla/gecko-dev",
+      "hg_root": "https://hg.mozilla.org/releases/mozilla-beta",
+      "objdir_path": "$WORKING/mozilla-beta/objdir",
+      "codesearch_path": "$WORKING/mozilla-beta/livegrep.idx",
+      "codesearch_port": 8081
+    },
+
+    "mozilla-release": {
+      "index_path": "$WORKING/mozilla-release",
+      "files_path": "$WORKING/mozilla-release/gecko-dev",
+      "git_path": "$WORKING/mozilla-release/gecko-dev",
+      "github_repo": "https://github.com/mozilla/gecko-dev",
+      "hg_root": "https://hg.mozilla.org/releases/mozilla-release",
+      "objdir_path": "$WORKING/mozilla-release/objdir",
+      "codesearch_path": "$WORKING/mozilla-release/livegrep.idx",
+      "codesearch_port": 8082
+    },
+
+    "mozilla-esr60": {
+      "index_path": "$WORKING/mozilla-esr60",
+      "files_path": "$WORKING/mozilla-esr60/gecko-dev",
+      "git_path": "$WORKING/mozilla-esr60/gecko-dev",
+      "github_repo": "https://github.com/mozilla/gecko-dev",
+      "hg_root": "https://hg.mozilla.org/releases/mozilla-esr60",
+      "objdir_path": "$WORKING/mozilla-esr60/objdir",
+      "codesearch_path": "$WORKING/mozilla-esr60/livegrep.idx",
+      "codesearch_port": 8082
+    }
+  }
+}

--- a/shared/fetch-gecko-dev.sh
+++ b/shared/fetch-gecko-dev.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# Helper script to download the gecko-dev tarball from S3
+# into the working dir if it hasn't already been downloaded,
+# and then unpack it into the specified destination folder.
+# This is a shared helper because we have multiple repos that
+# download the same tarball which takes time/bandwidth; doing
+# it once and reusing it saves about 3 minutes/7.5 Gb per
+# additional repo that uses it.
+
+DESTDIR="$1"
+
+if [ ! -f "$WORKING/gecko-dev.tar" ]; then
+    pushd "$WORKING"
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/gecko-dev.tar
+    popd
+fi
+
+tar xf "$WORKING/gecko-dev.tar" -C "$DESTDIR"


### PR DESCRIPTION
These patches add mozilla-{beta,release,esr60} repos, but do so in a new config file. This will allow us to index these trees on a separate indexer/webserver instance than the one that does the existing repos listed in config.json. See https://bugzilla.mozilla.org/show_bug.cgi?id=1282123#c2 for some context.

These patches have no dependencies in that they should be able to land without breaking anything.