### PR TITLE
Bug 1545056 - Ensure the local branch is updated when checking out a …

### DIFF
--- a/shared/checkout-gecko-repos.sh
+++ b/shared/checkout-gecko-repos.sh
@@ -38,7 +38,7 @@ echo Updating git
 pushd $GIT_ROOT
 git fetch origin
 if [ -n "$INDEXED_GIT_REV" ]; then
-    git checkout $INDEXED_GIT_REV
+    git checkout -B "$BRANCH" $INDEXED_GIT_REV
 else
     git checkout -B "$BRANCH" "origin/$BRANCH"
 fi


### PR DESCRIPTION
…taskcluster-indexed revision

The checkout command being modified was checking the gecko-dev repo
out to a "detached HEAD" instead of updating the local branch. While
this works correctly, it means that the local master branch for the
repo never gets updated to match upstream. This is subpar because
other repos (e.g. comm-central) do check out the local master branch
and it causes a lot of churn.