### PR TITLE
Bug 1545968 - Download and unpack the rust stdlib src and analysis data.

### DIFF
--- a/mozilla-beta/setup
+++ b/mozilla-beta/setup
@@ -9,6 +9,7 @@ set -o pipefail # Check all commands in a pipeline
 REVISION_TREE=mozilla-beta
 REVISION_ID=latest
 TRY_GIT_REV=
+export INDEX_RUSTLIB=no # until the m-c patches for bug 1545968 ride the trains to beta
 
 date
 

--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -13,6 +13,7 @@ date
 REVISION_TREE=mozilla-central       # replace with e.g. 'try' for testing
 REVISION_ID=latest                  # replace with e.g. 'revision.ee64db93dcc149da9313460317257b8c42eec5b2' for testing
 TRY_GIT_REV=                        # set to some gecko-dev SHA matching the above rev for testing
+export INDEX_RUSTLIB=yes            # opt in to downloading the rustlib analysis in fetch-tc-artifacts.sh
 
 # The next line populates the INDEXED_HG_REV and INDEXED_GIT_REV env vars.
 source $CONFIG_REPO/shared/resolve-gecko-revs.sh $REVISION_TREE $REVISION_ID

--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -38,6 +38,10 @@ for PLATFORM in linux64 macosx64 win64 android-armv7; do
     echo "${CURL} ${TC_PREFIX}/target.mozsearch-index.zip > ${PLATFORM}.mozsearch-index.zip" >> downloads.lst
     # Rust save-analysis files
     echo "${CURL} ${TC_PREFIX}/target.mozsearch-rust.zip > ${PLATFORM}.mozsearch-rust.zip" >> downloads.lst
+    if [ "$INDEX_RUSTLIB" == "yes" ]; then
+        # Rust stdlib src and analysis data
+        echo "${CURL} ${TC_PREFIX}/target.mozsearch-rust-stdlib.zip > ${PLATFORM}.mozsearch-rust-stdlib.zip" >> downloads.lst
+    fi
     # Generated sources tarballs
     echo "${CURL} ${TC_PREFIX}/target.generated-files.tar.gz > ${PLATFORM}.generated-files.tar.gz" >> downloads.lst
     # Manifest for dist/include entries

--- a/shared/process-tc-artifacts.sh
+++ b/shared/process-tc-artifacts.sh
@@ -27,6 +27,22 @@ unzip -q $PLATFORM.mozsearch-index.zip -d analysis-$PLATFORM
 # rust-indexer.rs tool will take care of combining all the analysis files correctly.
 unzip -q $PLATFORM.mozsearch-rust.zip -d objdir
 
+# If INDEX_RUSTLIB was set to "yes" during fetch-tc-artifacts.sh, then
+# we'll have per-platform rustlib src/analysis data in zip files, so
+# let's unpack those.
+if [ -f "$PLATFORM.mozsearch-rust-stdlib.zip" ]; then
+    # These zips have a rustlib top-level folder and then contain the
+    # rust stdlib src (all the zips have the same src tree) and analysis
+    # data for the platform. We unpack all the zips into the same
+    # destination folder, implicitly merging them. And we copy the stdlib
+    # src tree into the objdir and (ab)use the generated files machinery.
+    unzip -qn $PLATFORM.mozsearch-rust-stdlib.zip -d .
+    if [ ! -d "objdir/__RUST__" ]; then
+        mkdir -p "objdir/__RUST__"
+        cp -Rn rustlib/src/rust/src objdir/__RUST__/
+    fi
+fi
+
 # Unpack generated sources tarballs into platform-specific folder
 mkdir -p generated-$PLATFORM
 tar -x -z -C generated-$PLATFORM -f $PLATFORM.generated-files.tar.gz


### PR DESCRIPTION
This obsoletes #8. Now we get the src/analysis data from taskcluster rather than installing it on the indexer instance. This ensures that the data we get is in sync with the anaylsis data for the rest of m-c.

This depends on the m-c patches on bug 1545968 which are pending review.