### PR TITLE
Bug 1548123 - Remove unnecessary git reset

### DIFF
--- a/nss/setup
+++ b/nss/setup
@@ -58,7 +58,6 @@ date
 
 echo Updating git
 pushd $GIT_ROOT
-git reset --hard HEAD # Undo any changes from patches applied below.
 git pull
 popd
 


### PR DESCRIPTION
Now that the tarball in S3 has no uncommitted changes this reset is no longer needed.