### PR TITLE
Bug 1580266 - Specify mozilla-central as our default tree for help.html purposes. r=kats

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
   "mozsearch_path": "$MOZSEARCH_PATH",
 
+  "default_tree": "mozilla-central",
+
   "trees": {
     "nss": {
       "index_path": "$WORKING/nss",


### PR DESCRIPTION
We need this so that https://searchfox.org's default search box is mozilla-central.  This
depends on https://github.com/mozsearch/mozsearch/pull/240.