### PR TITLE
Remove tarball so that there's more disk space.

### DIFF
--- a/shared/fetch-gecko-tarball.sh
+++ b/shared/fetch-gecko-tarball.sh
@@ -33,3 +33,4 @@ if [ ! -f "$WORKING/${TARBALL}.tar" ]; then
 fi
 
 tar xf "$WORKING/${TARBALL}.tar" -C "$DESTDIR"
+rm "$WORKING/${TARBALL}.tar"


### PR DESCRIPTION
This allows me to get ash without indexed data in the default VM disk size.

We throw it away and re-generate it on upload anyway, so I think this is
harmless.