### PR TITLE
Bug 1583031 - Have rust analysis run (optionally) per-platform

### DIFF
--- a/shared/process-gecko-analysis.sh
+++ b/shared/process-gecko-analysis.sh
@@ -11,6 +11,10 @@ set -o pipefail # Check all commands in a pipeline
 echo "linux64 macosx64 win64 android-armv7" | tr " " "\n" |
 parallel --halt now,fail=1 "$CONFIG_REPO/shared/process-tc-artifacts.sh {}"
 
+# the script above ran the rust analysis, so drop this hacky file to tell
+# rust-analyze.sh to not do anything.
+touch objdir/rust-analyzed
+
 # Combine the per-platform list files
 cat generated-files-*.list > generated-files.list
 cat analysis-files-*.list > analysis-files.list

--- a/shared/process-tc-artifacts.sh
+++ b/shared/process-tc-artifacts.sh
@@ -47,6 +47,11 @@ tar -x -z -C generated-$PLATFORM -f $PLATFORM.generated-files.tar.gz
 
 date
 
+# Run the rust analysis here.
+$MOZSEARCH_PATH/scripts/rust-analyze.sh $CONFIG_FILE $TREE_NAME $PLATFORM
+
+date
+
 # Process the dist/include manifest and normalize away the taskcluster paths
 dos2unix --quiet --force $PLATFORM.distinclude.map  # need --force because of \x1f column separator chars in the file
 MAPVERSION=$(head -n 1 $PLATFORM.distinclude.map)


### PR DESCRIPTION
Depends on https://github.com/mozsearch/mozsearch/pull/251.

This changes the process-gecko-analysis.sh callers to process rust analysis data on a per-platform basis and inhibits the all-platforms invocation of rust-analyze.sh by mkindex.sh by dropping the hacky sentinel file.