### PR TITLE
Bug 1595492 - Update mapper downloading.

### DIFF
--- a/nss/setup
+++ b/nss/setup
@@ -56,8 +56,7 @@ date
 
 echo Downloading git to hg map
 pushd $INDEX_ROOT
-wget -nv https://mapper.mozilla-releng.net/nss/mapfile/full
-mv full git_hg.map
+curl -SsfL https://moz-vcssync.s3-us-west-2.amazonaws.com/mapping/nss-dev/git-mapfile.tar.bz2 | tar -xOj > git_hg.map
 popd
 
 date

--- a/shared/fetch-hg-map.sh
+++ b/shared/fetch-hg-map.sh
@@ -10,16 +10,12 @@ set -o pipefail # Check all commands in a pipeline
 # download the same thing on a given indexer.
 
 if [ ! -f "$WORKING/git_hg.map" ]; then
-    # We only need "recent" mapfile entries and attempting to download the full mapfile
-    # results in a 503 error so we just get the map entries from some fixed recent date.
-    DATE=2019-01-01
-
     rm -f "$WORKING/git_hg.map.tmp"
 
     # We combine this and the projects branch for convenience, as they share a
     # lot of revisions.
     for tree in gecko-dev gecko-projects; do
-      curl -SsfL https://mapper.mozilla-releng.net/$tree/mapfile/since/$DATE >> "$WORKING/git_hg.map.tmp"
+      curl -SsfL https://moz-vcssync.s3-us-west-2.amazonaws.com/mapping/$tree/git-mapfile.tar.bz2 | tar -xOj >> "$WORKING/git_hg.map.tmp"
     done
 
     # Remove duplicate entries from the map, which almost halves its size.


### PR DESCRIPTION
The mapper files are not .tar.bz2 files with paths that look like:
- build/conversion/nss-dev/.hg/git-mapfile
- ./build/conversion/beagle/.hg/git-mapfile (This is the gecko-dev mapping,
  I'm really hoping beagle is a codename and not the wrong source tree!)

Since we don't care about the paths and there's a single file, we can
use the "-O" option to tar to make it extract the contents to stdout.  So
the tar invocation becomes `-xOj` where x is extract and j is bz2
decompression.

I've tested this locally.