### PR TITLE
Bug 1596846 - Make sure to init new nested submodules as they appear. r=kats

### DIFF
--- a/mozilla-mobile/setup
+++ b/mozilla-mobile/setup
@@ -22,7 +22,8 @@ date
 
 echo Updating git
 pushd $GIT_ROOT
-git submodule update --recursive --remote
+git submodule update --remote # pull latest moz-mob code
+git submodule update --init --recursive # update nested submodule to desired revision
 git commit --allow-empty -am "Submodule update at $(date)" --author "Searchfox Indexer <searchfox-aws@mozilla.com>"
 popd
 


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1596846 which is about modifying the git repo you created in https://bugzilla.mozilla.org/show_bug.cgi?id=1530798.  I think I inferred the right actions to cargo cult, sans the call to init the nested submodule, but honestly my git submodule "expertise" is a bit rusty.

My intent here is to make sure that if our submodules gain any new submodules, they get properly initialized.  I understand this to be generally safe and correct.  The thing I'm a little concerned about is really the interaction with "--remote" in terms of the nested submodules.  I don't think I'm changing the semantics around that, but it appears like FirefoxReality's submodule is a specific revision to be checked out and my fear would be if we end up just always showing the tip of the `vrb` submodule instead of what the FirefoxReality repo wants checked out.

Of course, the easiest thing may be just to see what happens and ask :Agi on the bug to report back as to whether things seem right or wrong. :)