### PR TITLE
Bug 1596846 - bustage fix related to updates. r=asuth, a=bustage

### DIFF
--- a/mozilla-mobile/setup
+++ b/mozilla-mobile/setup
@@ -22,7 +22,13 @@ date
 
 echo Updating git
 pushd $GIT_ROOT
-git submodule update --remote # pull latest moz-mob code
+# pull latest moz-mob code.  We run this twice because of problems experienced
+# at https://bugzilla.mozilla.org/show_bug.cgi?id=1596846#c7.  This may be a
+# workaround for a git regression, as this didn't happen to 2.20.1 but did
+# happen on 2.24.0 and there were various changelog comments about changing when
+# various things were resolved.  For example,
+# https://github.com/git/git/blob/master/Documentation/RelNotes/2.23.0.txt#L36
+git submodule update --remote || git submodule update --remote
 git submodule update --init --recursive # update nested submodule to desired revision
 git commit --allow-empty -am "Submodule update at $(date)" --author "Searchfox Indexer <searchfox-aws@mozilla.com>"
 popd


### PR DESCRIPTION
@staktrace I'm going to merge this as a bustage fix right now, but I'm very interested in your thoughts here.  I'm keeping a copy of the unhappy tarball locally and have also replicated it to the backups/ directory at https://s3-us-west-2.amazonaws.com/searchfox.repositories/backups/mozilla-mobile.tar so interested parties can do some investigation of the situation, although it seems possible that what's on github may change or the github servers may get updated or something.