### PR TITLE
Bug 1619363 - Be case-insensitive when normalizing windows z: paths. r=kats

### DIFF
--- a/shared/collapse-generated-files.sh
+++ b/shared/collapse-generated-files.sh
@@ -34,11 +34,11 @@ function check_all_same {
     # Normalize to UNIX in-place. The z: absolute path comes from the taskcluster
     # working directory for Windows.
     dos2unix --quiet "$FIRSTFILE"
-    sed --in-place -e "s#z:/task_[0-9]*/#/builds/worker/workspace/#g" "$FIRSTFILE"
+    sed --in-place -e "s#z:/task_[0-9]*/#/builds/worker/workspace/#gI" "$FIRSTFILE"
     while [ $# -gt 0 ]; do
         NEXTFILE=$1; shift;
         dos2unix --quiet "$NEXTFILE"
-        sed --in-place -e "s#z:/task_[0-9]*/#/builds/worker/workspace/#g" "$NEXTFILE"
+        sed --in-place -e "s#z:/task_[0-9]*/#/builds/worker/workspace/#gI" "$NEXTFILE"
         cmp --quiet "$FIRSTFILE" "$NEXTFILE"
         if [ $? -ne 0 ]; then
             # Files aren't the same, echo empty string

--- a/shared/process-tc-artifacts.sh
+++ b/shared/process-tc-artifacts.sh
@@ -59,7 +59,7 @@ if [ "$MAPVERSION" != "5" ]; then
     echo "WARNING: $PLATFORM.distinclude.map had unexpected version [$MAPVERSION]; check for changes in python/mozbuild/mozpack/manifests.py."
 fi
 sed --in-place -e "s#/builds/worker/workspace/build/src/##g" $PLATFORM.distinclude.map
-sed --in-place -e "s#z:/task_[0-9]*/build/src/##g" $PLATFORM.distinclude.map
+sed --in-place -e "s#z:/task_[0-9]*/build/src/##gI" $PLATFORM.distinclude.map
 
 date
 


### PR DESCRIPTION
I tested the concept on one of the web-servers but haven't run with it.