### PR TITLE
Bug 1617567 - Move ESR60 to a new mozilla-archived config.

### DIFF
--- a/config.json
+++ b/config.json
@@ -71,7 +71,7 @@
       "hg_root": "https://hg.mozilla.org/mozilla-build/",
       "objdir_path": "$WORKING/mozilla-build/dist",
       "codesearch_path": "$WORKING/mozilla-build/livegrep.idx",
-      "codesearch_port": 8087
+      "codesearch_port": 8086
     },
 
     "glean": {
@@ -82,7 +82,7 @@
       "github_repo": "https://github.com/mozilla/glean",
       "objdir_path": "$WORKING/glean/objdir",
       "codesearch_path": "$WORKING/glean/livegrep.idx",
-      "codesearch_port": 8088
+      "codesearch_port": 8087
     }
   }
 }

--- a/mozilla-archived.json
+++ b/mozilla-archived.json
@@ -1,0 +1,18 @@
+{
+  "mozsearch_path": "$MOZSEARCH_PATH",
+
+  "trees": {
+    "mozilla-esr60": {
+      "index_path": "$WORKING/mozilla-esr60",
+      "files_path": "$WORKING/mozilla-esr60/gecko-dev",
+      "git_path": "$WORKING/mozilla-esr60/gecko-dev",
+      "git_blame_path": "$WORKING/mozilla-esr60/gecko-blame",
+      "github_repo": "https://github.com/mozilla/gecko-dev",
+      "hg_root": "https://hg.mozilla.org/releases/mozilla-esr60",
+      "dxr_root": "https://dxr.mozilla.org/mozilla-esr60",
+      "objdir_path": "$WORKING/mozilla-esr60/objdir",
+      "codesearch_path": "$WORKING/mozilla-esr60/livegrep.idx",
+      "codesearch_port": 8081
+    }
+  }
+}

--- a/mozilla-releases.json
+++ b/mozilla-releases.json
@@ -28,19 +28,6 @@
       "codesearch_port": 8082
     },
 
-    "mozilla-esr60": {
-      "index_path": "$WORKING/mozilla-esr60",
-      "files_path": "$WORKING/mozilla-esr60/gecko-dev",
-      "git_path": "$WORKING/mozilla-esr60/gecko-dev",
-      "git_blame_path": "$WORKING/mozilla-esr60/gecko-blame",
-      "github_repo": "https://github.com/mozilla/gecko-dev",
-      "hg_root": "https://hg.mozilla.org/releases/mozilla-esr60",
-      "dxr_root": "https://dxr.mozilla.org/mozilla-esr60",
-      "objdir_path": "$WORKING/mozilla-esr60/objdir",
-      "codesearch_path": "$WORKING/mozilla-esr60/livegrep.idx",
-      "codesearch_port": 8083
-    },
-
     "mozilla-esr68": {
       "index_path": "$WORKING/mozilla-esr68",
       "files_path": "$WORKING/mozilla-esr68/gecko-dev",

--- a/mozilla-releases.json
+++ b/mozilla-releases.json
@@ -37,7 +37,7 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr68",
       "objdir_path": "$WORKING/mozilla-esr68/objdir",
       "codesearch_path": "$WORKING/mozilla-esr68/livegrep.idx",
-      "codesearch_port": 8084
+      "codesearch_port": 8083
     }
   }
 }


### PR DESCRIPTION
I created a new target group called `mozilla-archived-target`, ran the indexer on this config, and hooked it all up, so it's live. Going to https://searchfox.org/mozilla-esr60/source right now will serve the content from the `mozilla-archived` web-server instance. I'll update docs and add more ESR repos in separate patches.