### PR TITLE
Bug 1617567 - Have the m-c indexer build blame for more ESRs

### DIFF
--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -28,7 +28,7 @@ date
 # because it's best to have only one indexer instance responsible for updating and
 # pushing the tarball to S3, to avoid accidental clobbers. It's not a great situation
 # architecturally, but it's better for performance.
-for BRANCH in beta release esr60 esr68; do
+for BRANCH in beta release esr68 esr60 esr45 esr32 esr17; do
     echo "Updating gecko-dev branch $BRANCH to latest from upstream..."
     pushd $GIT_ROOT
     git branch -f $BRANCH origin/$BRANCH || git branch -f $BRANCH projects/$BRANCH


### PR DESCRIPTION
This is the first step in adding the new ESRs, as it will create the necessary named branches in the gecko-dev and gecko-blame tarballs. Once this runs on an release indexer and the resulting tarballs are uploaded into S3, I can make the final change which adds the new repos to mozilla-archived.json.