### PR TITLE
Revert "Bug 1617567 - Have the m-c indexer build blame for more ESRs"

### DIFF
--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -28,7 +28,7 @@ date
 # because it's best to have only one indexer instance responsible for updating and
 # pushing the tarball to S3, to avoid accidental clobbers. It's not a great situation
 # architecturally, but it's better for performance.
-for BRANCH in beta release esr68 esr60 esr45 esr32 esr17; do
+for BRANCH in beta release esr60 esr68; do
     echo "Updating gecko-dev branch $BRANCH to latest from upstream..."
     pushd $GIT_ROOT
     git branch -f $BRANCH origin/$BRANCH || git branch -f $BRANCH projects/$BRANCH


### PR DESCRIPTION
This reverts commit 29627e2632864520e721713ad35b03f6c2245f53, it's not doing what I expect it to.