### PR TITLE
Make a glean build failure non-fatal

### DIFF
--- a/glean/build
+++ b/glean/build
@@ -5,5 +5,5 @@ set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
 pushd $GIT_ROOT
-RUSTFLAGS="-Z save-analysis" cargo +nightly check --all --target-dir=$OBJDIR
+RUSTFLAGS="-Z save-analysis" cargo +nightly check --all --target-dir=$OBJDIR || echo "WARNING: Glean build failed, see log for details"
 popd


### PR DESCRIPTION
I'd like to keep mozilla-central `build` failures fatal, so I don't want to catch errors at the call site for this build script. Instead, let's make the glean repo non-fatal. I haven't actually tested this patch in that commands later in the indexing run might fail due to not finding analysis files or something.