### PR TITLE
Bug 1616362 - Run python-modernize on all the python scripts

### DIFF
--- a/find-repo-files.py
+++ b/find-repo-files.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+from __future__ import absolute_import
 import os
 import os.path
 import sys
@@ -8,6 +9,7 @@ import json
 import collections
 
 from lib import run
+from six.moves import range
 
 config = json.load(open(sys.argv[1]))
 tree_name = sys.argv[2]


### PR DESCRIPTION
This adds a dependency on `six` which the indexer already has due
to boto3 relying on it.