### PR TITLE
Bug 1641079 - Make `__GENERATED__/__RUST__` work. r=kats

### DIFF
--- a/mozilla-central/check
+++ b/mozilla-central/check
@@ -23,3 +23,6 @@ date
 
 ## XPIDL Bindings (libxpcom)
 "$@" "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" "xpcom::interfaces::idl::nsIChannel"
+
+## rustlib std library stuff
+"$@" "__GENERATED__/__RUST__/liballoc/collections/btree/map.rs" "alloc::collections::btree::map::BTreeMap"


### PR DESCRIPTION
I moved the generated extraction up so that generated-$PLATFORM would already be created by the time the rust stdlib move stuff happens.

Again, feel free to merge this with the other and change the check as needed.  Also of course feel free to not land and request changes and all that good stuff.  I just won't be up before the indexing runs start tomorrow morning :)