### PR TITLE
Bug 1641679 - Update gecko-dev branches from the correct remote.

### DIFF
--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -35,9 +35,9 @@ date
 # pushing the tarball to S3, to avoid accidental clobbers. It's not a great situation
 # architecturally, but it's better for performance.
 for BRANCH in beta release esr68 esr60 esr45 esr31 esr17; do
-    echo "Updating gecko-dev branch $BRANCH to latest from upstream..."
+    echo "Updating gecko-dev branch $BRANCH to latest from cinnabar upstream..."
     pushd $GIT_ROOT
-    git branch -f $BRANCH origin/$BRANCH || git branch -f $BRANCH projects/$BRANCH
+    git branch -f $BRANCH $BRANCH/branches/default/tip
     popd
     echo "Generating blame information for $BRANCH..."
     BLAME_REF="refs/heads/$BRANCH" $MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT


### PR DESCRIPTION
We were updating the branches in gecko-dev from the "origin" remote which we're no longer pulling updates to. I should have just deleted that remote when I was migrating to cinnabar, as that would have caused this line to throw an error which I would have caught. But anyhoo, this should fix it so we update from cinnabar. I'm also manually updating the blame repo and will push it to S3 so tomorrow's indexer don't have to do as much work. I've backed up the current tarballs in case I screw up.