### PR TITLE
Bug 1644745 - Fetch new default branch for Glean

### DIFF
--- a/glean/setup
+++ b/glean/setup
@@ -36,7 +36,7 @@ date
 
 echo Updating git
 pushd $GIT_ROOT
-git pull origin master
+git pull origin main
 popd
 
 echo Generating blame information


### PR DESCRIPTION
We renamed the default branch (and I forgot that we did have automatic tooling that is based on it).
The new default branch is called `main`, so pulling that in should continue to work as is.