### PR TITLE
Bug 1646069 - Normalize rust build script output paths. r=kats

### DIFF
--- a/mozilla-central/check
+++ b/mozilla-central/check
@@ -25,4 +25,6 @@ date
 "$@" "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" "xpcom::interfaces::idl::nsIChannel"
 
 ## rustlib std library stuff
-"$@" "__GENERATED__/__RUST__/liballoc/collections/btree/map.rs" "alloc::collections::btree::map::BTreeMap"
+"$@" "__GENERATED__/__RUST_STDLIB__/liballoc/collections/btree/map.rs" "alloc::collections::btree::map::BTreeMap"
+
+## TODO: Add webrender's shaders.rs once the test run completes.


### PR DESCRIPTION
Per discussion in https://github.com/mozsearch/mozsearch/pull/348 normalize
paths to:

- `__GENERATED__/__linux64__/__RUST_STDLIB__/...` for stdlib
- `__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs` for crate-generated