### PR TITLE
Bug 1646069 - Add webrender shaders.rs check. r=kats

### DIFF
--- a/mozilla-central/check
+++ b/mozilla-central/check
@@ -27,4 +27,11 @@ date
 ## rustlib std library stuff
 "$@" "__GENERATED__/__RUST_STDLIB__/liballoc/collections/btree/map.rs" "alloc::collections::btree::map::BTreeMap"
 
-## TODO: Add webrender's shaders.rs once the test run completes.
+## Check that webrender's build-script generated shaders.rs exists for linux
+# Because this file includes a bunch of hashes and paths, it ends up being
+# platform specific.  We could check all platforms, but historically Windows
+# analyses are sometimes missing, and we intentionally made that condition
+# non-fatal.  Also, this is primarily a test of our normalization logic in
+# `process-tc-artifacts.sh` which involves platforms, but the logic isn't
+# particularly platform specific.
+"$@" "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs" "webrender::shader_source::OPTIMIZED_SHADERS"


### PR DESCRIPTION
I ran `~/mozsearch/infrastructure/web-server-check.sh ~/config ~/index ~` on the "asuth" server (which I'm leaving up for now so you can check stuff and should feel free to login to) and here's the excerpt of that specific check which covers both filesystem and network checks.

In the patch I only check linux and do some hand-waving about that because I don't want us to break if windows takes a day off, but we can check the other platforms too or all of them, etc.  I'm fine with whatever, really, just didn't want to make the daily runs brittle for no reason.  (Also, I'm assuming the shaders thing will stick around for a while?)

```
+ /home/ubuntu/mozsearch/scripts/check-helper.sh filesystem http://localhost/ __GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs webrender::shader_source::OPTIMIZED_SHADERS
+ set -eu                                                                                                                                                                                     
+ set -o pipefail
+ [[ 4 -ne 4 ]]                           
+ CHECK_DISK=filesystem                     
+ CHECK_SERVER_URL=http://localhost/      
+ SEARCHFOX_PATH=__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
+ SYMBOL_NAME=webrender::shader_source::OPTIMIZED_SHADERS
+ [[ -n filesystem ]]                     
+ LOCAL_ANALYSIS_PATH=/home/ubuntu/index/mozilla-central/analysis/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
+ LOCAL_HTML_PATH=/home/ubuntu/index/mozilla-central/file/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs                                                                
+ [[ ! -f /home/ubuntu/index/mozilla-central/analysis/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs ]]
+ grep -m1 '"sym":"webrender::shader_source::OPTIMIZED_SHADERS"' /home/ubuntu/index/mozilla-central/analysis/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
{"loc":"00067:17-34","source":1,"syntax":"","pretty":"static webrender::shader_source::OPTIMIZED_SHADERS","sym":"webrender::shader_source::OPTIMIZED_SHADERS"}
+ [[ ! -f /home/ubuntu/index/mozilla-central/analysis/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs ]]
+ egrep -m1 -e 'data-symbols="webrender::shader_source::OPTIMIZED_SHADERS[",]' /home/ubuntu/index/mozilla-central/file/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
  <code role="cell" class="source-line">  <span class="syn_reserved" >pub</span> <span class="syn_reserved" >static</span> <span class="syn_reserved" >ref</span> <span data-symbols="webrende
r::shader_source::OPTIMIZED_SHADERS,webrender::shader_source::OPTIMIZED_SHADERS" data-i="192" >OPTIMIZED_SHADERS</span>: <span data-symbols="std::collections::hash::map::HashMap" data-i="193
" >HashMap</span>&lt;(<span data-symbols="webrender_build::shader::ShaderVersion" data-i="194" >ShaderVersion</span>, &amp;'static str), <span data-symbols="webrender::shader_source::Optimiz
edSourceWithDigest" data-i="195" >OptimizedSourceWithDigest</span>> = {              
+ [[ -n http://localhost/ ]]                                                                   
+ SERVER_ANALYSIS_URL=http://localhost/mozilla-central/raw-analysis/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
+ SERVER_HTML_URL=http://localhost/mozilla-central/source/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
+ SERVER_SYMBOL_SEARCH_URL='http://localhost/mozilla-central/search?q=symbol:webrender::shader_source::OPTIMIZED_SHADERS'
+ grep -m1 '"sym":"webrender::shader_source::OPTIMIZED_SHADERS"' /dev/fd/63    
++ curl -fs http://localhost/mozilla-central/raw-analysis/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
{"loc":"00067:17-34","source":1,"syntax":"","pretty":"static webrender::shader_source::OPTIMIZED_SHADERS","sym":"webrender::shader_source::OPTIMIZED_SHADERS"}
+ egrep -m1 -e 'data-symbols="webrender::shader_source::OPTIMIZED_SHADERS[",]' /dev/fd/63
++ curl -fs http://localhost/mozilla-central/source/__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
  <code role="cell" class="source-line">  <span class="syn_reserved" >pub</span> <span class="syn_reserved" >static</span> <span class="syn_reserved" >ref</span> <span data-symbols="webrende
r::shader_source::OPTIMIZED_SHADERS,webrender::shader_source::OPTIMIZED_SHADERS" data-i="192" >OPTIMIZED_SHADERS</span>: <span data-symbols="std::collections::hash::map::HashMap" data-i="193
" >HashMap</span>&lt;(<span data-symbols="webrender_build::shader::ShaderVersion" data-i="194" >ShaderVersion</span>, &amp;'static str), <span data-symbols="webrender::shader_source::Optimiz
edSourceWithDigest" data-i="195" >OptimizedSourceWithDigest</span>> = {
+ JQ_FIND_DEF_EXPR=to_entries                                                                                                                                                                 
+ JQ_FIND_DEF_EXPR+=' | map(.value.Definitions? // [])'
+ JQ_FIND_DEF_EXPR+=' | flatten'          
+ JQ_FIND_DEF_EXPR+=' | map(.path == "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs")'
+ JQ_FIND_DEF_EXPR+=' | any'              
+ jq 'to_entries | map(.value.Definitions? // []) | flatten | map(.path == "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs") | any' /dev/fd/63
++ curl -fs -H 'Accept: application/json' 'http://localhost/mozilla-central/search?q=symbol:webrender::shader_source::OPTIMIZED_SHADERS'
true                                                                                           
+ set +x                                                                                       
=========================================                                                      
SUCCESS: Integrity check passed for webrender::shader_source::OPTIMIZED_SHADERS in __GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs
=========================================                                                      
```