### PR TITLE
Bug 1650538 - Add link to comm-esr78 on main help page

### DIFF
--- a/help.html
+++ b/help.html
@@ -74,6 +74,7 @@ subdirectories (i.e., <code>*</code> does not match <code>/</code>).
        <tr><td><a href="/mozilla-beta/source">mozilla-beta</a></td>         <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-release/source">mozilla-release</a></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-esr78/source">mozilla-esr78</a></td>       <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
+       <tr><td><a href="/comm-esr78/source">comm-esr78</a></td>             <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       </tr>
        <tr><td><a href="/mozilla-esr68/source">mozilla-esr68</a></td>       <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       </tr>
        <tr><td><a href="/comm-esr68/source">comm-esr68</a></td>             <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       </tr>
        <tr><td><a href="/mozilla-esr60/source">mozilla-esr60</a></td>       <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       <td></td>       </tr>


### PR DESCRIPTION
Forgot this in #105 