### PR TITLE
Bug 1653986 - Download test info for gecko-dev builds and define a wpt_root for m-c. r=kats

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
       "hg_root": "https://hg.mozilla.org/mozilla-central",
       "dxr_root": "https://dxr.mozilla.org/mozilla-central",
       "ccov_root": "https://coverage.moz.tools/",
+      "wpt_root": "testing/web-platform",
       "objdir_path": "$WORKING/mozilla-central/objdir",
       "codesearch_path": "$WORKING/mozilla-central/livegrep.idx",
       "codesearch_port": 8082

--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -15,7 +15,16 @@ INDEXED_HG_REV=$2
 PREEXISTING_HG_REV=$3
 
 # Allow caller to override what we use to download, but
-# have a sane default
+# have a sane default:
+# -s AKA --silent: No progress or error messages unless...
+# -S AKA --show-error: Show an error message despite --silent
+# -f AKA --fail: Emit nothing to standard out on server errors (which would
+#                usually be a boring HTML page), returning error code 22.
+# -L AKA --location: Follow redirects (using the "Location" header)
+#
+# Want it to be an optional call that doesn't fail the build if the file isn't
+# there?  Then try:
+# ${CURL} url -o outut-location || true
 CURL=${CURL:-"curl -SsfL --compressed"}
 
 # Rewrite REVISION to be a specific revision in case the "latest" pointer changes while
@@ -38,6 +47,8 @@ fi
 # we're indexing. But do them in parallel by emitting all the curl commands into
 # a file and then feeding it to GNU parallel.
 echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.$REVISION.source.source-bugzilla-info/artifacts/public/components-normalized.json > bugzilla-components.json" > downloads.lst
+echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.$REVISION.source.test-info-all/artifacts/public/test-info-all-tests.json -o test-info-all-tests.json || true" >> downloads.lst
+echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.$REVISION.source.source-wpt-metadata-summary/artifacts/public/summary.json -o wpt-metadata-summary.json || true" >> downloads.lst
 for PLATFORM in linux64 macosx64 win64 android-armv7; do
     TC_PREFIX="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.${REVISION}.firefox.${PLATFORM}-searchfox-debug/artifacts/public/build"
     # First check that the searchfox job exists for the platform and revision we want. Otherwise emit a warning and skip it. This


### PR DESCRIPTION
This adds a wpt_root and downloads the test and WPT info in an optional fashion.