### PR TITLE
Bug 1566874 - Initial coverage hookup. r=kats

### DIFF
--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -49,6 +49,12 @@ fi
 echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.$REVISION.source.source-bugzilla-info/artifacts/public/components-normalized.json > bugzilla-components.json" > downloads.lst
 echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.$REVISION.source.test-info-all/artifacts/public/test-info-all-tests.json -o test-info-all-tests.json || true" >> downloads.lst
 echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.$REVISION.source.source-wpt-metadata-summary/artifacts/public/summary.json -o wpt-metadata-summary.json || true" >> downloads.lst
+# Unfortunately, at the current time, we can't rely on the specific coverage data
+# for the given revision to already have been built (see bug 1566874), so we
+# attempt to fetch the correct revision but fail over to the "latest" revision
+# if we couldn't get the explicit revision.  And coverage data is optional; we
+# won't error out if we can't fetch any coverage.
+echo "${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.relman.code-coverage.production.repo.${REVISION_TREE}.${INDEXED_HG_REV}/artifacts/public/code-coverage-report.json -o code-coverage-report.json || ${CURL} https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.relman.code-coverage.production.repo.${REVISION_TREE}.latest/artifacts/public/code-coverage-report.json -o code-coverage-report.json || true" >> downloads.lst
 for PLATFORM in linux64 macosx64 win64 android-armv7; do
     TC_PREFIX="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.${REVISION}.firefox.${PLATFORM}-searchfox-debug/artifacts/public/build"
     # First check that the searchfox job exists for the platform and revision we want. Otherwise emit a warning and skip it. This


### PR DESCRIPTION
The hookup for this is simple, but as covered in https://bugzilla.mozilla.org/show_bug.cgi?id=1566874 the coverage bot/taskcluster hookup isn't currently reliably timely enough for us to demand the same revision Searchfox was built against.  This is probably better than nothing for now?