### PR TITLE
Bug 1672405 - Support changed folder structure in rust-src tarball in rust 1.47 and up.

### DIFF
--- a/mozilla-central/check
+++ b/mozilla-central/check
@@ -25,7 +25,7 @@ date
 "$@" "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" "xpcom::interfaces::idl::nsIChannel"
 
 ## rustlib std library stuff
-"$@" "__GENERATED__/__RUST_STDLIB__/liballoc/collections/btree/map.rs" "alloc::collections::btree::map::BTreeMap"
+"$@" "__GENERATED__/__RUST_STDLIB__/alloc/src/collections/btree/map.rs" "alloc::collections::btree::map::BTreeMap"
 
 ## Check that webrender's build-script generated shaders.rs exists for linux
 # Because this file includes a bunch of hashes and paths, it ends up being


### PR DESCRIPTION
(Just need one review, changes are relatively straightforward)