### PR TITLE
Fix process-tc-artifacts.sh for rust 1.47 stdlib.

### DIFF
--- a/shared/process-tc-artifacts.sh
+++ b/shared/process-tc-artifacts.sh
@@ -119,8 +119,8 @@ if [ -f "$PLATFORM.mozsearch-rust-stdlib.zip" ]; then
     # In rust-src-1.47 the folder structure changed to have "library" instead
     # of "src", so we try both here, since this code needs to work with rust
     # versions before and after 1.47.
-    mv -f objdir-$PLATFORM/rustlib/src/rust/src generated-$PLATFORM/__RUST_STDLIB__ ||
-        mv -f objdir-$PLATFORM/rustlib/src/rust/library generated-$PLATFORM/__RUST_STDLIB__
+    mv -f objdir-$PLATFORM/rustlib/src/rust/library generated-$PLATFORM/__RUST_STDLIB__ ||
+        mv -f objdir-$PLATFORM/rustlib/src/rust/src generated-$PLATFORM/__RUST_STDLIB__
 fi
 
 date


### PR DESCRIPTION
In rust 1.47 the library is indeed in /library, but there's also
stuff under /src (just `llvm-project/libunwind`).

Since it's not empty we were copying it instead of the rust stdlib.

We could copy both instead, though that might need adding wildcards and
complicating the script. This fixes the indexing error and we can do
that in a follow-up, though it's not clear that having libunwind gives
us much benefit.