### PR TITLE
Bug 1684371 - Update yq syntax for yq version 4.2.0

### DIFF
--- a/mingw-moz/setup
+++ b/mingw-moz/setup
@@ -34,7 +34,7 @@ popd
 
 date
 
-MOZ_REV=$(curl -SsfL "https://hg.mozilla.org/mozilla-central/raw-file/tip/taskcluster/ci/fetch/toolchains.yml" | yq read - "mingw-w64.fetch.revision")
+MOZ_REV=$(curl -SsfL "https://hg.mozilla.org/mozilla-central/raw-file/tip/taskcluster/ci/fetch/toolchains.yml" | yq eval ".mingw-w64.fetch.revision" -)
 
 echo Updating git
 pushd $GIT_ROOT


### PR DESCRIPTION
I tested by running the command in question on today's release2 indexer which is still going