### PR TITLE
Bug 1690181 - Normalize the config4.json repos git/blame folders

### DIFF
--- a/config4.json
+++ b/config4.json
@@ -56,8 +56,8 @@
 
     "whatwg-html": {
       "index_path": "$WORKING/whatwg-html",
-      "files_path": "$WORKING/whatwg-html/html",
-      "git_path": "$WORKING/whatwg-html/html",
+      "files_path": "$WORKING/whatwg-html/git",
+      "git_path": "$WORKING/whatwg-html/git",
       "git_blame_path": "$WORKING/whatwg-html/blame",
       "github_repo": "https://github.com/whatwg/html",
       "objdir_path": "$WORKING/whatwg-html/objdir",
@@ -67,8 +67,8 @@
 
     "mozilla-build": {
       "index_path": "$WORKING/mozilla-build",
-      "files_path": "$WORKING/mozilla-build/mozilla-build",
-      "git_path": "$WORKING/mozilla-build/mozilla-build",
+      "files_path": "$WORKING/mozilla-build/git",
+      "git_path": "$WORKING/mozilla-build/git",
       "git_blame_path": "$WORKING/mozilla-build/blame",
       "hg_root": "https://hg.mozilla.org/mozilla-build/",
       "objdir_path": "$WORKING/mozilla-build/dist",
@@ -78,9 +78,9 @@
 
     "glean": {
       "index_path": "$WORKING/glean",
-      "files_path": "$WORKING/glean/glean",
-      "git_path": "$WORKING/glean/glean",
-      "git_blame_path": "$WORKING/glean/glean-blame",
+      "files_path": "$WORKING/glean/git",
+      "git_path": "$WORKING/glean/git",
+      "git_blame_path": "$WORKING/glean/blame",
       "github_repo": "https://github.com/mozilla/glean",
       "objdir_path": "$WORKING/glean/objdir",
       "codesearch_path": "$WORKING/glean/livegrep.idx",

--- a/glean/setup
+++ b/glean/setup
@@ -8,7 +8,7 @@ date
 
 echo Downloading glean repo
 pushd $INDEX_ROOT
-if [ -d "glean" ]
+if [ -d "git" ]
 then
     echo "Found pre-existing folder; skipping re-download."
 else
@@ -22,7 +22,7 @@ date
 
 echo Downloading glean blame.
 pushd $INDEX_ROOT
-if [ -d "glean-blame" ]
+if [ -d "blame" ]
 then
     echo "Found pre-existing blame folder; skipping re-download."
 else

--- a/glean/upload
+++ b/glean/upload
@@ -8,7 +8,7 @@ date
 
 echo Uploading glean
 pushd $INDEX_ROOT
-tar cf glean.tar glean
+tar cf glean.tar git
 $AWS_ROOT/upload.py $INDEX_ROOT/glean.tar searchfox.repositories glean.tar
 rm glean.tar
 popd
@@ -17,7 +17,7 @@ date
 
 echo Uploading glean blame
 pushd $INDEX_ROOT
-tar cf glean-blame.tar glean-blame
+tar cf glean-blame.tar blame
 $AWS_ROOT/upload.py $INDEX_ROOT/glean-blame.tar searchfox.repositories glean-blame.tar
 rm glean-blame.tar
 popd

--- a/mozilla-build/setup
+++ b/mozilla-build/setup
@@ -8,7 +8,7 @@ date
 
 echo Downloading mozilla-build repo
 pushd $INDEX_ROOT
-if [ -d "mozilla-build" ]
+if [ -d "git" ]
 then
     echo "Found pre-existing folder; skipping re-download."
 else

--- a/mozilla-build/upload
+++ b/mozilla-build/upload
@@ -8,7 +8,7 @@ date
 
 echo Uploading mozilla-build
 pushd $INDEX_ROOT
-tar cf mozilla-build.tar mozilla-build
+tar cf mozilla-build.tar git
 $AWS_ROOT/upload.py $INDEX_ROOT/mozilla-build.tar searchfox.repositories mozilla-build.tar
 rm mozilla-build.tar
 popd

--- a/whatwg-html/setup
+++ b/whatwg-html/setup
@@ -8,13 +8,13 @@ date
 
 echo Downloading WHATWG HTML repo
 pushd $INDEX_ROOT
-if [ -d "html" ]
+if [ -d "git" ]
 then
-    echo "Found pre-existing html folder; skipping re-download."
+    echo "Found pre-existing git folder; skipping re-download."
 else
-    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/whatwg-html-git.tar
-    tar xf whatwg-html-git.tar
-    rm whatwg-html-git.tar
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/whatwg-html.tar
+    tar xf whatwg-html.tar
+    rm whatwg-html.tar
 fi
 popd
 

--- a/whatwg-html/upload
+++ b/whatwg-html/upload
@@ -8,9 +8,9 @@ date
 
 echo Uploading WHATWG HTML
 pushd $INDEX_ROOT
-tar cf whatwg-html-git.tar html
-$AWS_ROOT/upload.py $INDEX_ROOT/whatwg-html-git.tar searchfox.repositories whatwg-html-git.tar
-rm whatwg-html-git.tar
+tar cf whatwg-html.tar git
+$AWS_ROOT/upload.py $INDEX_ROOT/whatwg-html.tar searchfox.repositories whatwg-html.tar
+rm whatwg-html.tar
 popd
 
 date


### PR DESCRIPTION
This makes it so that all the repos listed in config4.json extract
their git tarballs into a `git` folder and their blame tarballs into
a `blame` folder. This is good for consistency and scriptability.
Also the tarball names are now `<repo-name>.tar` for the git tarball
and `<repo-name-blame>.tar` for the blame tarball.