### PR TITLE
Bug 1690181 - Rename gecko-dev.tar to gecko.tar

### DIFF
--- a/comm-central/setup
+++ b/comm-central/setup
@@ -42,7 +42,7 @@ if [ -d "mozilla" ]
 then
     echo "Found pre-existing mozilla subfolder; skipping re-download."
 else
-    $CONFIG_REPO/shared/fetch-gecko-tarball.sh gecko-dev $PWD
+    $CONFIG_REPO/shared/fetch-gecko-tarball.sh gecko $PWD
     mv gecko-dev mozilla
 fi
 

--- a/mozilla-central/upload
+++ b/mozilla-central/upload
@@ -8,21 +8,21 @@ date
 
 echo Uploading Gecko
 pushd $INDEX_ROOT
-tar cf gecko-dev.tar gecko-dev
+tar cf gecko.tar gecko-dev
 # If the tarball gets bigger than 10GB, re-compress the repo
-TARBALL_SIZE=$(stat -c '%s' gecko-dev.tar)
+TARBALL_SIZE=$(stat -c '%s' gecko.tar)
 TEN_GIGS=$((10 * 1000 * 1000 * 1000))
 if [ $TARBALL_SIZE -gt $TEN_GIGS ]; then
     git --git-dir=gecko-dev/.git gc
-    tar cf gecko-dev.tar gecko-dev
+    tar cf gecko.tar gecko-dev
     # If it's still bigger than 10GB, spit out a warning
-    TARBALL_SIZE=$(stat -c '%s' gecko-dev.tar)
+    TARBALL_SIZE=$(stat -c '%s' gecko.tar)
     if [ $TARBALL_SIZE -gt $TEN_GIGS ]; then
-        echo "WARNING: gecko-dev.tar is bigger than 10GB even after git gc. Try more aggressive gc, or increase size limit"
+        echo "WARNING: gecko.tar is bigger than 10GB even after git gc. Try more aggressive gc, or increase size limit"
     fi
 fi
-$AWS_ROOT/upload.py $INDEX_ROOT/gecko-dev.tar searchfox.repositories gecko-dev.tar
-rm gecko-dev.tar
+$AWS_ROOT/upload.py $INDEX_ROOT/gecko.tar searchfox.repositories gecko.tar
+rm gecko.tar
 popd
 
 date

--- a/nss/setup
+++ b/nss/setup
@@ -32,9 +32,9 @@ if [ -d "git" ]
 then
     echo "Found pre-existing git folder; skipping re-download."
 else
-    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss-git.tar
-    tar xf nss-git.tar
-    rm nss-git.tar
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/nss.tar
+    tar xf nss.tar
+    rm nss.tar
 fi
 popd
 

--- a/nss/upload
+++ b/nss/upload
@@ -8,9 +8,9 @@ date
 
 echo Uploading NSPR
 pushd $INDEX_ROOT
-tar cf nss-git.tar git
-$AWS_ROOT/upload.py $INDEX_ROOT/nss-git.tar searchfox.repositories nss-git.tar
-rm nss-git.tar
+tar cf nss.tar git
+$AWS_ROOT/upload.py $INDEX_ROOT/nss.tar searchfox.repositories nss.tar
+rm nss.tar
 popd
 
 date

--- a/shared/checkout-gecko-repos.sh
+++ b/shared/checkout-gecko-repos.sh
@@ -16,7 +16,7 @@ INDEXED_HG_REV=$3
 
 echo Downloading Gecko
 pushd $INDEX_ROOT
-$CONFIG_REPO/shared/fetch-gecko-tarball.sh gecko-dev $PWD
+$CONFIG_REPO/shared/fetch-gecko-tarball.sh gecko $PWD
 popd
 
 date

--- a/shared/fetch-gecko-tarball.sh
+++ b/shared/fetch-gecko-tarball.sh
@@ -4,7 +4,7 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-# Helper script to download the gecko-dev or gecko-blame tarball from S3
+# Helper script to download the gecko or gecko-blame tarball from S3
 # into the working dir if it hasn't already been downloaded,
 # and then unpack it into the specified destination folder.
 # This is a shared helper because we have multiple repos that
@@ -13,7 +13,7 @@ set -o pipefail # Check all commands in a pipeline
 # additional repo that uses it.
 
 if [ $# -ne 2 ]; then
-    echo "Usage: $0 <gecko-dev|gecko-blame> <destination>"
+    echo "Usage: $0 <gecko|gecko-blame> <destination>"
     echo " e.g.: $0 gecko-blame \$PWD"
     exit 1
 fi
@@ -21,8 +21,20 @@ fi
 TARBALL="$1"
 DESTDIR="$2"
 
-if [ -d "${DESTDIR}/${TARBALL}" ]; then
-    echo "Found pre-existing folder at ${DESTDIR}/${TARBALL}, skipping re-download..."
+# This is a bit of a hack, but there are only two allowed values for
+# TARBALL so it's not terrible. And anyway (almost) no other repo
+# respects this convention of having the top-level folder inside the
+# tarball match the tarball name, since most repos use "git" and "blame"
+# folders inside their tarballs, and someday the gecko tarballs will
+# as well.
+if [[ "$TARBALL" == "gecko" ]]; then
+    TARBALL_FOLDER="gecko-dev"
+elif [[ "$TARBALL" == "gecko-blame" ]]; then
+    TARBALL_FOLDER="gecko-blame"
+fi
+
+if [ -d "${DESTDIR}/${TARBALL_FOLDER}" ]; then
+    echo "Found pre-existing folder at ${DESTDIR}/${TARBALL_FOLDER}, skipping re-download..."
     exit 0
 fi
 


### PR DESCRIPTION
All the other repos have their git repo in `<foo>.tar` and
blame repo in `<foo>-blame.tar`. gecko-dev is unique in using
`gecko-dev.tar` and `gecko-blame.tar`. This patch brings gecko
in line with the other repos, by changing the git tarball to
be `gecko.tar`. Note that the folder inside is still `gecko-dev`;
eventually it will be renamed to `git` to match other
repositories but that'll happen when I'm more in the mood to
manually download and re-upload a 10G tarball.