### PR TITLE
Bug 1712622 - Index the m-c pine project branch. r=kats

### DIFF
--- a/config4.json
+++ b/config4.json
@@ -118,6 +118,17 @@
       "objdir_path": "$WORKING/kaios/objdir",
       "codesearch_path": "$WORKING/kaios/livegrep.idx",
       "codesearch_port": 8091
+    },
+
+    "mozilla-pine": {
+      "index_path": "$WORKING/mozilla-pine",
+      "files_path": "$WORKING/mozilla-pine/git",
+      "git_path": "$WORKING/mozilla-pine/git",
+      "git_blame_path": "$WORKING/mozilla-pine/blame",
+      "hg_root": "https://hg.mozilla.org/projects/pine",
+      "objdir_path": "$WORKING/mozilla-pine/objdir",
+      "codesearch_path": "$WORKING/mozilla-pine/livegrep.idx",
+      "codesearch_port": 8092
     }
   }
 }

--- a/mozilla-central/reblame
+++ b/mozilla-central/reblame
@@ -9,5 +9,5 @@ set -o pipefail # Check all commands in a pipeline
 # as to minimize the amount of new work needed. The order of branches
 # in the loop is also selected to reduce unnecessary work; changing the
 # order should not affect correctness but may increase redundant work.
-BRANCHES="beta release esr78 esr68 esr60 esr45 esr31 esr17"
+BRANCHES="pine beta release esr78 esr68 esr60 esr45 esr31 esr17"
 $CONFIG_REPO/shared/rebuild-blame.sh --tarball-base gecko --branches "${BRANCHES}" $*

--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -34,7 +34,7 @@ date
 # because it's best to have only one indexer instance responsible for updating and
 # pushing the tarball to S3, to avoid accidental clobbers. It's not a great situation
 # architecturally, but it's better for performance.
-for BRANCH in beta release esr78 esr68 esr60 esr45 esr31 esr17; do
+for BRANCH in pine beta release esr78 esr68 esr60 esr45 esr31 esr17; do
     echo "Updating gecko-dev branch $BRANCH to latest from cinnabar upstream..."
     pushd $GIT_ROOT
     git branch -f $BRANCH $BRANCH/branches/default/tip

--- a/mozilla-central/setup
+++ b/mozilla-central/setup
@@ -34,13 +34,24 @@ date
 # because it's best to have only one indexer instance responsible for updating and
 # pushing the tarball to S3, to avoid accidental clobbers. It's not a great situation
 # architecturally, but it's better for performance.
+#
+# Base case for dynamic branch creation, see below.
+LASTBRANCH="master"
+# If you are adding branches, add them after the branch they forked off of,
+# putting the branch at the front of the list if they forked off of m-c.  So
+# in the case of new ESR branches (which fork off of "release"), they go after
+# release and before existing ESR branches.
 for BRANCH in pine beta release esr78 esr68 esr60 esr45 esr31 esr17; do
     echo "Updating gecko-dev branch $BRANCH to latest from cinnabar upstream..."
     pushd $GIT_ROOT
     git branch -f $BRANCH $BRANCH/branches/default/tip
     popd
     echo "Generating blame information for $BRANCH..."
+    # Check if there's a branch in the blame repo yet, and if there isn't, fork
+    # it from the previous branch in the list, with a base case of "master".
+    git -C $BLAME_ROOT show-ref --verify --quiet "refs/heads/${BRANCH}" || git -C $BLAME_ROOT branch "${BRANCH}" "${LASTBRANCH}"
     BLAME_REF="refs/heads/$BRANCH" $MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT
+    LASTBRANCH="${BRANCH}"
 done
 
 date

--- a/mozilla-pine/build
+++ b/mozilla-pine/build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# For now we don't do any C++ analysis, but we may end up doing so.

--- a/mozilla-pine/repo_files.py
+++ b/mozilla-pine/repo_files.py
@@ -1,0 +1,9 @@
+def filter_ipdl(path):
+    if 'ipc/ipdl/test' in path:
+        return False
+    return True
+
+def filter_js(path):
+    if 'js/src/tests' in path or 'jit-test' in path:
+        return False
+    return True

--- a/mozilla-pine/setup
+++ b/mozilla-pine/setup
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# See ../mozilla-central/setup for documentation
+# The mozilla-central repo also uploads an updated gecko.tar which
+# includes pine commits, so we don't need our own upload script.
+
+REVISION_TREE=pine
+REVISION_ID=latest
+
+date
+
+source $CONFIG_REPO/shared/resolve-gecko-revs.sh $REVISION_TREE $REVISION_ID
+
+date
+
+$CONFIG_REPO/shared/checkout-gecko-repos.sh $REVISION_TREE "pine" "$INDEXED_HG_REV"
+
+date
+
+$CONFIG_REPO/shared/fetch-tc-artifacts.sh $REVISION_TREE $INDEXED_HG_REV "$PREEXISTING_HG_REV"
+
+date

--- a/shared/checkout-gecko-repos.sh
+++ b/shared/checkout-gecko-repos.sh
@@ -38,6 +38,7 @@ pushd $GIT_ROOT
 # If we need to fetch project branches in the future, we can fetch those also with cinnabar here.
 # Note that this repo may still have a 'projects' and a 'cinnabar' remote left over that we don't use any more.
 git config remote.central.url || git remote add -t branches/default/tip central hg::https://hg.mozilla.org/mozilla-central
+git config remote.pine.url || git remote add -t branches/default/tip pine hg::https://hg.mozilla.org/projects/pine
 git config remote.beta.url || git remote add -t branches/default/tip beta hg::https://hg.mozilla.org/releases/mozilla-beta
 git config remote.release.url || git remote add -t branches/default/tip release hg::https://hg.mozilla.org/releases/mozilla-release
 git config remote.esr78.url || git remote add -t branches/default/tip esr78 hg::https://hg.mozilla.org/releases/mozilla-esr78
@@ -48,7 +49,7 @@ git config remote.esr31.url || git remote add -t branches/default/tip esr31 hg::
 git config remote.esr17.url || git remote add -t branches/default/tip esr17 hg::https://hg.mozilla.org/releases/mozilla-esr17
 git config cinnabar.graft false
 git config fetch.prune true
-git fetch --multiple central beta release esr78 esr68 esr60 esr45 esr31 esr17
+git fetch --multiple central pine beta release esr78 esr68 esr60 esr45 esr31 esr17
 
 # If a try push was specified, pull it in non-graft mode so we actually pull those changes.
 if [ "$REVISION_TREE" == "try" ]; then


### PR DESCRIPTION
I know for "ash" we just called it "ash", but it seems like having the
"mozilla-" prefix better conveys that's it's an m-c branch and that it
uses the same underlying gecko repo/etc. while avoiding the problems
of using "mozilla-central" as a prefix like in "mozilla-central-pine".

I put this in config4 because config4 currently has the fastest indexing
time per my analysis at
https://bugzilla.mozilla.org/show_bug.cgi?id=1712622#c1 and our disk
usage is also relatively low, at 41G / 240G

I'm intentionally leaving this off the help.html listing for now per
discussion with the branch owners.