### PR TITLE
Bug 1712622 - enable pine semantic indexing in build script

### DIFF
--- a/mozilla-pine/build
+++ b/mozilla-pine/build
@@ -4,4 +4,10 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-# For now we don't do any C++ analysis, but we may end up doing so.
+date
+
+pushd $INDEX_ROOT
+$CONFIG_REPO/shared/process-gecko-analysis.sh
+popd
+
+date


### PR DESCRIPTION
When I transitioned from skipping the analysis to building it, I forgot
to update the build script from the no-op build script.