### PR TITLE
Bug 1722889 - Update check target to one that still exists

### DIFF
--- a/mozilla-central/check
+++ b/mozilla-central/check
@@ -16,7 +16,7 @@ date
 ### Rust
 ## First-Party Rust
 # libwebrender
-"$@" "gfx/webrender_bindings/src/moz2d_renderer.rs" "webrender_bindings::moz2d_renderer::Box2d"
+"$@" "gfx/webrender_bindings/src/moz2d_renderer.rs" "webrender_bindings::moz2d_renderer::CacheKey"
 
 ## Third-Party Rust
 "$@" "third_party/rust/euclid/src/rect.rs" "euclid::rect::Rect"


### PR DESCRIPTION
In bug 1711648 the Box2d type was removed from the webrender
bindings code, so this check started failing. Updating it to
reference a different type from the same file that is less
likely to be deleted.