### PR TITLE
Bug 1716167 - Run maintenance for submodules as well

### DIFF
--- a/l10n/upload
+++ b/l10n/upload
@@ -8,10 +8,19 @@ date
 
 echo Uploading l10n
 pushd $INDEX_ROOT
+
+echo "Running maintenance on l10n submodules..."
+for submod in ./git/*; do
+    $CONFIG_REPO/shared/git-maintenance.sh "${submod}"
+done
+echo "Running maintenance on l10n supermodule..."
 $CONFIG_REPO/shared/git-maintenance.sh ./git
+echo "Maintenance complete!"
+
 tar cf l10n.tar git
 $AWS_ROOT/upload.py $INDEX_ROOT/l10n.tar searchfox.repositories l10n.tar
 rm l10n.tar
+
 popd
 
 date

--- a/mozilla-mobile/upload
+++ b/mozilla-mobile/upload
@@ -8,10 +8,19 @@ date
 
 echo Uploading mozilla-mobile
 pushd $INDEX_ROOT
+
+echo "Running maintenance on mozilla-mobile submodules..."
+pushd ./git
+git submodule foreach --recursive "${CONFIG_REPO}/shared/git-maintenance.sh \$PWD"
+popd
+echo "Running maintenance on mozilla-mobile supermodule..."
 $CONFIG_REPO/shared/git-maintenance.sh ./git
+echo "Maintenance complete!"
+
 tar cf mozilla-mobile.tar git
 $AWS_ROOT/upload.py $INDEX_ROOT/mozilla-mobile.tar searchfox.repositories mozilla-mobile.tar
 rm mozilla-mobile.tar
+
 popd
 
 date


### PR DESCRIPTION
For l10n, the submodules are cinnabar repos and need
regular cinnabar fsck runs to avoid warnings, so let's do
that.

Even ignoring the cinnabar warnings, doing regular gc on
the submodules is a good idea, so we do it for mozilla-mobile
as well. In that case there's no cinnabar submodules so
we can use the more normal foreach subcommand rather than
manually looping through the submodules.