### PR TITLE
Bug 1729178 - Enable serde_json preserve_order feature

### DIFF
--- a/mozilla-central/checks/snapshots/check_glob@rust__build__webrender_shader__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__build__webrender_shader__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00066:17-34",
+    "target": 1,
+    "kind": "def",
     "pretty": "webrender::shader_source::OPTIMIZED_SHADERS",
-    "sym": "webrender::shader_source::OPTIMIZED_SHADERS",
-    "target": 1
+    "sym": "webrender::shader_source::OPTIMIZED_SHADERS"
   }
 ]

--- a/mozilla-central/checks/snapshots/check_glob@rust__first_party__webrender__moz2d__def__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__first_party__webrender__moz2d__def__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00277:7-15",
+    "target": 1,
+    "kind": "def",
     "pretty": "webrender_bindings::moz2d_renderer::CacheKey",
-    "sym": "webrender_bindings::moz2d_renderer::CacheKey",
-    "target": 1
+    "sym": "webrender_bindings::moz2d_renderer::CacheKey"
   }
 ]

--- a/mozilla-central/checks/snapshots/check_glob@rust__stdlib__btreemap__def__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__stdlib__btreemap__def__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00143:11-19",
+    "target": 1,
+    "kind": "def",
     "pretty": "alloc::collections::btree::map::BTreeMap",
-    "sym": "alloc::collections::btree::map::BTreeMap",
-    "target": 1
+    "sym": "alloc::collections::btree::map::BTreeMap"
   }
 ]

--- a/mozilla-central/checks/snapshots/check_glob@rust__third_party__euclid__def__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__third_party__euclid__def__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00052:11-15",
+    "target": 1,
+    "kind": "def",
     "pretty": "euclid::rect::Rect",
-    "sym": "euclid::rect::Rect",
-    "target": 1
+    "sym": "euclid::rect::Rect"
   }
 ]

--- a/mozilla-central/checks/snapshots/check_glob@rust__xpidl__nsichannel__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__xpidl__nsichannel__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00015:11-21",
+    "target": 1,
+    "kind": "def",
     "pretty": "xpcom::interfaces::idl::nsIChannel",
-    "sym": "xpcom::interfaces::idl::nsIChannel",
-    "target": 1
+    "sym": "xpcom::interfaces::idl::nsIChannel"
   }
 ]


### PR DESCRIPTION
Test expectations re-derived updated after applying
https://github.com/mozsearch/mozsearch/pull/446

This maintained input JSON key ordering.