### PR TITLE
Bug 1738166 - Update mozilla-central checks to use production-filter

### DIFF
--- a/mozilla-central/checks/inputs/rust__build__webrender_shader__html
+++ b/mozilla-central/checks/inputs/rust__build__webrender_shader__html
@@ -1,1 +1,1 @@
-filter-analysis "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs" -k def -s "webrender::shader_source::OPTIMIZED_SHADERS" | show-html
+filter-analysis "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs" -k def -s "webrender::shader_source::OPTIMIZED_SHADERS" | show-html | production-filter

--- a/mozilla-central/checks/inputs/rust__build__webrender_shader__json
+++ b/mozilla-central/checks/inputs/rust__build__webrender_shader__json
@@ -1,1 +1,1 @@
-filter-analysis "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs" -k def -s "webrender::shader_source::OPTIMIZED_SHADERS"
+filter-analysis "__GENERATED__/__linux64__/__RUST_BUILD_SCRIPT__/webrender/shaders.rs" -k def -s "webrender::shader_source::OPTIMIZED_SHADERS" | production-filter

--- a/mozilla-central/checks/inputs/rust__first_party__webrender__moz2d__def__html
+++ b/mozilla-central/checks/inputs/rust__first_party__webrender__moz2d__def__html
@@ -1,1 +1,1 @@
-filter-analysis "gfx/webrender_bindings/src/moz2d_renderer.rs" -k def -s "webrender_bindings::moz2d_renderer::CacheKey" | show-html
+filter-analysis "gfx/webrender_bindings/src/moz2d_renderer.rs" -k def -s "webrender_bindings::moz2d_renderer::CacheKey" | show-html | production-filter

--- a/mozilla-central/checks/inputs/rust__first_party__webrender__moz2d__def__json
+++ b/mozilla-central/checks/inputs/rust__first_party__webrender__moz2d__def__json
@@ -1,1 +1,1 @@
-filter-analysis "gfx/webrender_bindings/src/moz2d_renderer.rs" -k def -s "webrender_bindings::moz2d_renderer::CacheKey"
+filter-analysis "gfx/webrender_bindings/src/moz2d_renderer.rs" -k def -s "webrender_bindings::moz2d_renderer::CacheKey" | production-filter

--- a/mozilla-central/checks/inputs/rust__stdlib__btreemap__def__html
+++ b/mozilla-central/checks/inputs/rust__stdlib__btreemap__def__html
@@ -1,1 +1,1 @@
-filter-analysis "__GENERATED__/__RUST_STDLIB__/alloc/src/collections/btree/map.rs" -k def -s "alloc::collections::btree::map::BTreeMap" | show-html
+filter-analysis "__GENERATED__/__RUST_STDLIB__/alloc/src/collections/btree/map.rs" -k def -s "alloc::collections::btree::map::BTreeMap" | show-html | production-filter

--- a/mozilla-central/checks/inputs/rust__stdlib__btreemap__def__json
+++ b/mozilla-central/checks/inputs/rust__stdlib__btreemap__def__json
@@ -1,1 +1,1 @@
-filter-analysis "__GENERATED__/__RUST_STDLIB__/alloc/src/collections/btree/map.rs" -k def -s "alloc::collections::btree::map::BTreeMap"
+filter-analysis "__GENERATED__/__RUST_STDLIB__/alloc/src/collections/btree/map.rs" -k def -s "alloc::collections::btree::map::BTreeMap" | production-filter

--- a/mozilla-central/checks/inputs/rust__third_party__euclid__def__json
+++ b/mozilla-central/checks/inputs/rust__third_party__euclid__def__json
@@ -1,1 +1,1 @@
-filter-analysis "third_party/rust/euclid/src/rect.rs" -k def -s "euclid::rect::Rect"
+filter-analysis "third_party/rust/euclid/src/rect.rs" -k def -s "euclid::rect::Rect" | production-filter

--- a/mozilla-central/checks/inputs/rust__xpidl__nsichannel__html
+++ b/mozilla-central/checks/inputs/rust__xpidl__nsichannel__html
@@ -1,1 +1,1 @@
-filter-analysis "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" -k def -s "xpcom::interfaces::idl::nsIChannel" | show-html
+filter-analysis "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" -k def -s "xpcom::interfaces::idl::nsIChannel" | show-html | production-filter

--- a/mozilla-central/checks/inputs/rust__xpidl__nsichannel__json
+++ b/mozilla-central/checks/inputs/rust__xpidl__nsichannel__json
@@ -1,1 +1,1 @@
-filter-analysis "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" -k def -s "xpcom::interfaces::idl::nsIChannel"
+filter-analysis "__GENERATED__/dist/xpcrs/rt/nsIChannel.rs" -k def -s "xpcom::interfaces::idl::nsIChannel" | production-filter

--- a/mozilla-central/checks/snapshots/check_glob@rust__build__webrender_shader__html.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__build__webrender_shader__html.snap
@@ -3,9 +3,11 @@ source: tests/test_check_insta.rs
 expression: "&aggr_str"
 
 ---
-<div role="row" id="line-67" class="source-line-with-number">
-  <div role="cell" class="line-number" data-line-number="67"></div>
-  <code role="cell" class="source-line">  <span class="syn_reserved" >pub</span> <span class="syn_reserved" >static</span> <span class="syn_reserved" >ref</span> <span data-symbols="webrender::shader_source::OPTIMIZED_SHADERS,webrender::shader_source::OPTIMIZED_SHADERS" data-i="192" >OPTIMIZED_SHADERS</span>: <span data-symbols="std::collections::hash::map::HashMap" data-i="193" >HashMap</span>&lt;(<span data-symbols="webrender_build::shader::ShaderVersion" data-i="194" >ShaderVersion</span>, &amp;'static str), <span data-symbols="webrender::shader_source::OptimizedSourceWithDigest" data-i="195" >OptimizedSourceWithDigest</span>> = {
+<div role="row" id="line-NORM" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
+  <div role="cell" class="line-number" data-line-number="NORM"></div>
+  <code role="cell" class="source-line">  <span class="syn_reserved" >pub</span> <span class="syn_reserved" >static</span> <span class="syn_reserved" >ref</span> <span data-symbols="webrender::shader_source::OPTIMIZED_SHADERS,webrender::shader_source::OPTIMIZED_SHADERS" data-i="NORM">OPTIMIZED_SHADERS</span>: <span data-symbols="std::collections::hash::map::HashMap" data-i="NORM">HashMap</span>&lt;(<span data-symbols="webrender_build::shader::ShaderVersion" data-i="NORM">ShaderVersion</span>, &amp;'static str), <span data-symbols="webrender::shader_source::OptimizedSourceWithDigest" data-i="NORM">OptimizedSourceWithDigest</span>> = {
 </code>
 </div>
 

--- a/mozilla-central/checks/snapshots/check_glob@rust__build__webrender_shader__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__build__webrender_shader__json.snap
@@ -5,7 +5,7 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00067:17-34",
+    "loc": "NORM:17-34",
     "target": 1,
     "kind": "def",
     "pretty": "webrender::shader_source::OPTIMIZED_SHADERS",

--- a/mozilla-central/checks/snapshots/check_glob@rust__first_party__webrender__moz2d__def__html.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__first_party__webrender__moz2d__def__html.snap
@@ -3,9 +3,11 @@ source: tests/test_check_insta.rs
 expression: "&aggr_str"
 
 ---
-<div role="row" id="line-277" class="source-line-with-number nesting-sticky-line">
-  <div role="cell" class="line-number" data-line-number="277"></div>
-  <code role="cell" class="source-line"><span class="syn_reserved" >struct</span> <span data-symbols="webrender_bindings::moz2d_renderer::CacheKey" data-i="308" >CacheKey</span> {
+<div role="row" id="line-NORM" class="source-line-with-number nesting-sticky-line">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip c2" data-blame="92039c823e438dcfb2f3a19b09c9be1d83657051#%#277" role="button" aria-label="same hash 6" aria-expanded="false"></div></div>
+  <div role="cell" class="line-number" data-line-number="NORM"></div>
+  <code role="cell" class="source-line"><span class="syn_reserved" >struct</span> <span data-symbols="webrender_bindings::moz2d_renderer::CacheKey" data-i="NORM">CacheKey</span> {
 </code>
 </div>
 

--- a/mozilla-central/checks/snapshots/check_glob@rust__first_party__webrender__moz2d__def__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__first_party__webrender__moz2d__def__json.snap
@@ -5,7 +5,7 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00277:7-15",
+    "loc": "NORM:7-15",
     "target": 1,
     "kind": "def",
     "pretty": "webrender_bindings::moz2d_renderer::CacheKey",

--- a/mozilla-central/checks/snapshots/check_glob@rust__stdlib__btreemap__def__html.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__stdlib__btreemap__def__html.snap
@@ -3,9 +3,11 @@ source: tests/test_check_insta.rs
 expression: "&aggr_str"
 
 ---
-<div role="row" id="line-143" class="source-line-with-number">
-  <div role="cell" class="line-number" data-line-number="143"></div>
-  <code role="cell" class="source-line"><span class="syn_reserved" >pub</span> <span class="syn_reserved" >struct</span> <span data-symbols="alloc::collections::btree::map::BTreeMap" data-i="4" >BTreeMap</span>&lt;K, V> {
+<div role="row" id="line-NORM" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
+  <div role="cell" class="line-number" data-line-number="NORM"></div>
+  <code role="cell" class="source-line"><span class="syn_reserved" >pub</span> <span class="syn_reserved" >struct</span> <span data-symbols="alloc::collections::btree::map::BTreeMap" data-i="NORM">BTreeMap</span>&lt;K, V> {
 </code>
 </div>
 

--- a/mozilla-central/checks/snapshots/check_glob@rust__stdlib__btreemap__def__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__stdlib__btreemap__def__json.snap
@@ -5,7 +5,7 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00143:11-19",
+    "loc": "NORM:11-19",
     "target": 1,
     "kind": "def",
     "pretty": "alloc::collections::btree::map::BTreeMap",

--- a/mozilla-central/checks/snapshots/check_glob@rust__third_party__euclid__def__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__third_party__euclid__def__json.snap
@@ -5,7 +5,7 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00052:11-15",
+    "loc": "NORM:11-15",
     "target": 1,
     "kind": "def",
     "pretty": "euclid::rect::Rect",

--- a/mozilla-central/checks/snapshots/check_glob@rust__xpidl__nsichannel__html.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__xpidl__nsichannel__html.snap
@@ -3,9 +3,11 @@ source: tests/test_check_insta.rs
 expression: "&aggr_str"
 
 ---
-<div role="row" id="line-15" class="source-line-with-number nesting-sticky-line">
-  <div role="cell" class="line-number" data-line-number="15"></div>
-  <code role="cell" class="source-line"><span class="syn_reserved" >pub</span> <span class="syn_reserved" >struct</span> <span data-symbols="xpcom::interfaces::idl::nsIChannel" data-i="0" >nsIChannel</span> {
+<div role="row" id="line-NORM" class="source-line-with-number nesting-sticky-line">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
+  <div role="cell" class="line-number" data-line-number="NORM"></div>
+  <code role="cell" class="source-line"><span class="syn_reserved" >pub</span> <span class="syn_reserved" >struct</span> <span data-symbols="xpcom::interfaces::idl::nsIChannel" data-i="NORM">nsIChannel</span> {
 </code>
 </div>
 

--- a/mozilla-central/checks/snapshots/check_glob@rust__xpidl__nsichannel__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@rust__xpidl__nsichannel__json.snap
@@ -5,7 +5,7 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00015:11-21",
+    "loc": "NORM:11-21",
     "target": 1,
     "kind": "def",
     "pretty": "xpcom::interfaces::idl::nsIChannel",


### PR DESCRIPTION
The new "production-filter" check should address false positives in the
check process from line numbers and similar data changing.

This is just the result of running the review script with https://github.com/mozsearch/mozsearch/pull/459 applied.