### PR TITLE
Unbreak mozilla-mobile, probably

### DIFF
--- a/mozilla-mobile/setup
+++ b/mozilla-mobile/setup
@@ -28,7 +28,11 @@ pushd $GIT_ROOT
 # happen on 2.24.0 and there were various changelog comments about changing when
 # various things were resolved.  For example,
 # https://github.com/git/git/blob/master/Documentation/RelNotes/2.23.0.txt#L36
-git submodule update --remote || git submodule update --remote
+#
+# the prune stuff is to deal with encountering this error:
+#   error: cannot lock ref 'refs/remotes/origin/mergify': 'refs/remotes/origin/mergify/bp/main/pr-5560' exists; cannot create 'refs/remotes/origin/mergify'
+# I'm wrapping it in the and because we still want to do the update.
+git submodule update --remote || git submodule update --remote || (git submodule foreach --recursive git remote prune origin && git submodule update --remote)
 # The previous step will update the submodules of this top-level synthetic superproject,
 # and now we want to commit those changes, so that the top-level superproject points
 # to the latest version of each submodule.


### PR DESCRIPTION
The follow bad thing happened:
```
+ pushd /mnt/index-scratch/mozilla-mobile/git
/mnt/index-scratch/mozilla-mobile/git ~
+ git submodule update --remote
From https://github.com/mozilla-mobile/android-components
   1f0e0c8b2e..2d152a477f  main       -> origin/main
Submodule path 'android-components': checked out '2d152a477f3c1ca162304db466a504753c0c9f24'
From https://github.com/mozilla-mobile/firefox-ios
 * [new branch]          lm/#9422-Epic-branch-bottom-searchbar -> origin/lm/#9422-Epic-branch-bottom-searchbar
   a62962279..df6c2db93  update-br-new-xcode-version -> origin/update-br-new-xcode-version
From https://github.com/mozilla-mobile/focus-android
   3887ed02..0d874021  main                    -> origin/main
error: cannot lock ref 'refs/remotes/origin/mergify': 'refs/remotes/origin/mergify/bp/main/pr-5560' exists; cannot create 'refs/remotes/origin/mergify'
 ! [new branch]        mergify                 -> origin/mergify  (unable to update local ref)
 * [new branch]        oana-androidxDepUpgrade -> origin/oana-androidxDepUpgrade
fatal: Unable to fetch in submodule path 'focus-android'
+ git submodule update --remote
error: cannot lock ref 'refs/remotes/origin/mergify': 'refs/remotes/origin/mergify/bp/main/pr-5560' exists; cannot create 'refs/remotes/origin/mergify'
From https://github.com/mozilla-mobile/focus-android
 ! [new branch]        mergify    -> origin/mergify  (unable to update local ref)
fatal: Unable to fetch in submodule path 'focus-android'
```

I tried random things suggested by the internet until
`git submodule update --remote` started working.  This is that fix,
productized!

Ideally someone with a more direct interest in mozilla-mobile will step up in
the future!