### PR TITLE
Add a config that's just mozilla-central for expedited testing.

### DIFF
--- a/just-mc.json
+++ b/just-mc.json
@@ -1,0 +1,21 @@
+{
+  "mozsearch_path": "$MOZSEARCH_PATH",
+
+  "default_tree": "mozilla-central",
+
+  "trees": {
+    "mozilla-central": {
+      "index_path": "$WORKING/mozilla-central",
+      "files_path": "$WORKING/mozilla-central/git",
+      "git_path": "$WORKING/mozilla-central/git",
+      "git_blame_path": "$WORKING/mozilla-central/blame",
+      "github_repo": "https://github.com/mozilla/gecko-dev",
+      "hg_root": "https://hg.mozilla.org/mozilla-central",
+      "ccov_root": "https://coverage.moz.tools/",
+      "wpt_root": "testing/web-platform",
+      "objdir_path": "$WORKING/mozilla-central/objdir",
+      "codesearch_path": "$WORKING/mozilla-central/livegrep.idx",
+      "codesearch_port": 8082
+    }
+  }
+}


### PR DESCRIPTION
In particular, in cases where I want to update the test expectations
for m-c, it's nice to be able to do this without having to create a new
branch, etc.

I'd previously entertained having a filter mechanism for this, and I
think I may even have patches for that, but this seems more
straightforward in terms of understanding what's happening with tags in
the AWS instance list, etc.