### PR TITLE
Bug 1759064 - Update checks for multiple source recs

### DIFF
--- a/mozilla-central/checks/snapshots/check_glob@xpidl__xpctest_params__def_testOctet__html.snap
+++ b/mozilla-central/checks/snapshots/check_glob@xpidl__xpctest_params__def_testOctet__html.snap
@@ -7,7 +7,7 @@ expression: "&aggr_str"
   <div role="cell"></div>
   <div role="cell"></div>
   <div role="cell" class="line-number" data-line-number="NORM"></div>
-  <code role="cell" class="source-line">  <span class="syn_reserved" >octet</span>                 <span class="syn_def" data-symbols="_ZN16nsIXPCTestParams9TestOctetEhPhS0_,#testOctet" data-i="NORM">testOctet</span>(<span class="syn_reserved" >in</span> <span class="syn_reserved" >octet</span> a, <span class="syn_reserved" >inout</span> <span class="syn_reserved" >octet</span> b);
+  <code role="cell" class="source-line">  <span class="syn_reserved" >octet</span>                 <span class="syn_def syn_def" data-symbols="_ZN16nsIXPCTestParams9TestOctetEhPhS0_,_ZN16nsIXPCTestParams9TestOctetEhPhS0_,#testOctet" data-i="NORM">testOctet</span>(<span class="syn_reserved" >in</span> <span class="syn_reserved" >octet</span> a, <span class="syn_reserved" >inout</span> <span class="syn_reserved" >octet</span> b);
 </code>
 </div>
 

--- a/mozilla-central/checks/snapshots/check_glob@xpidl__xpctest_params__def_testOctet__json.snap
+++ b/mozilla-central/checks/snapshots/check_glob@xpidl__xpctest_params__def_testOctet__json.snap
@@ -15,6 +15,13 @@ expression: "&json_results"
     "loc": "24:24-33",
     "source": 1,
     "syntax": "idl",
+    "pretty": "IDL C++ method testOctet",
+    "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_"
+  },
+  {
+    "loc": "24:24-33",
+    "source": 1,
+    "syntax": "idl",
     "pretty": "IDL method testOctet",
     "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_,#testOctet"
   },


### PR DESCRIPTION
This is from following the steps documented at
https://github.com/mozsearch/mozsearch/blob/master/docs/testing-checks.md#updating-checks-on-a-stopped-aws-indexer-due-to-local-disk-check-failure
after triggering a just-mc run.

I have not added extra checks for the attributes case because my chicken
nuggets are done and I would like to eat them and this check is a pretty
good smoke test check given that it's consistent with our checks in the
tests repo too and all failures would be correlated!