### PR TITLE
Bug 1759930 - Filter out IDL files for ESR builds with pre-python3 xpidl.py

### DIFF
--- a/mozilla-esr17/repo_files.py
+++ b/mozilla-esr17/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_idl(path):
+    # ESR17 doesn't even have an XPIDL parser we'll recognize but let's bypass
+    # trying to use a modern one.
+    return False

--- a/mozilla-esr31/repo_files.py
+++ b/mozilla-esr31/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_idl(path):
+    # ESR31 doesn't even have an XPIDL parser we'll recognize but let's bypass
+    # trying to use a modern one.
+    return False

--- a/mozilla-esr45/repo_files.py
+++ b/mozilla-esr45/repo_files.py
@@ -7,3 +7,7 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_idl(path):
+    # ESR45's XPIDL parser is python2 only
+    return False

--- a/mozilla-esr60/repo_files.py
+++ b/mozilla-esr60/repo_files.py
@@ -7,3 +7,7 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_idl(path):
+    # ESR60's XPIDL parser is python2 only
+    return False

--- a/mozilla-esr68/repo_files.py
+++ b/mozilla-esr68/repo_files.py
@@ -7,3 +7,7 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_idl(path):
+    # ESR68's XPIDL parser is python2 only
+    return False


### PR DESCRIPTION
I use the IDL filtering mechanism here to disable XPIDL analysis on older ESR
branches for 2 reasons:

1. ESR45, ESR60, ESR68 all have in-tree versions that we'll try to use but
   which aren't legal Python 3 code, which means when we try and use them we'll
   throw once per file.  The python 3 compatible versions don't indicate
   they want to use python3 on the first line which meant a more involved
   attempt at shell detection.  And handling the error in the Python still
   would potentially result in N error messages if we have any error messages.
2. ESR17 and ESR31 both pre-date having an xpidl.py in that path we look for
   it, but it seems likely the modern parser is more likely to encounter
   problems because of this but we don't really care.  It's more of an accident
   that we try and parse the IDL files.  (Note: I recently changed the parser
   to emit errors/warnings on trunk because we do care about supporting IDL on
   our more modern branches.)