### PR TITLE
Bug 1771804 - Only treat .js files as JS

### DIFF
--- a/wubkat/repo_files.py
+++ b/wubkat/repo_files.py
@@ -1,0 +1,12 @@
+def filter_ipdl(path):
+    # webkit does not have IPDL!
+    return False
+
+def filter_idl(path):
+    # webkit does not have XPIDL!
+    return False
+
+def filter_js(path):
+    # webkit does not have XUL, and its `.inc` files appear to at least
+    # sometimes be metal shaders!
+    return path.endswith(".js")


### PR DESCRIPTION
js-analyze was trying to parse a metal `.inc` shader which is not a
thing that will go well.  (I think it was trying to parse it as XUL,
because that's what .inc files historically were in m-c, but still,
it appropriately did not go well.)

It may be appropriate to let a config.json specify that JS failures are
non-fatal, or even to make JS analysis failures non-fatal by default.
It's possible for the LSIF support we may move to effectively doing
this.