### PR TITLE
Bug 1771804 - fix typo so that we tar up "blame" not "git" as blame

### DIFF
--- a/wubkat/upload
+++ b/wubkat/upload
@@ -20,7 +20,7 @@ date
 echo Uploading webkit blame
 pushd $INDEX_ROOT
 $CONFIG_REPO/shared/git-maintenance.sh ./blame
-tar cf - git | lz4 - wubkat-blame.tar.lz4
+tar cf - blame | lz4 - wubkat-blame.tar.lz4
 $AWS_ROOT/upload.py $INDEX_ROOT/wubkat-blame.tar.lz4 searchfox.repositories wubkat-blame.tar.lz4
 rm wubkat-blame.tar.lz4
 popd


### PR DESCRIPTION
Very bad brain typo here (correlated with some fatigue); thankfully I
had backed up the blame on S3 in our backups dir and so there's only a
small number of blame revisions that will need to be recomputed.  I
think this was a little worse because I was also trying to do the new
lz4 thing at the same time as permuting the names.

I also took this opportunity to update the wubkat `git` tarball backup
so that we also have the (very slow to download) flatpaks backed up too
in case something bad happens to that S3 storage.  (We're not currently
using versioning it looks like, so it seems like there are situations
where things could go badly for us.)