### PR TITLE
Bug 1786930 - Build wubkat using last successful revision.

### DIFF
--- a/wubkat/last-successful-build-to-git-commit.sh
+++ b/wubkat/last-successful-build-to-git-commit.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# This is dpino's script from
+# https://gist.github.com/dpino/b324320652bb8b758acde123f9a3dbdc
+# specifically
+# https://gist.githubusercontent.com/dpino/b324320652bb8b758acde123f9a3dbdc/raw/87d75cfe4ff8aa8a4d2fd7f86dfc507f18cd58fa/last-successful-build-to-git-commit.sh
+#
+# Many thanks to dpino!
+
+# set -x
+
+BUILDER_NAME=${1:-GTK-Linux-64-bit-Release-Ubuntu-LTS-Build}
+if [[ -z $WEBKIT_CHECKOUT_DIR ]]; then
+    WEBKIT_CHECKOUT_DIR=${2:-$(realpath $(dirname "$0"))}
+fi
+
+usage() {
+    local exit_code="$1"
+    local program_name=$(basename "$0")
+
+    echo -e "Usage: $program_name BOT-NAME [WEBKIT-CHECKOUT-DIR]"
+    echo -e "Returns commit of last succeessful build in BOT-NAME"
+
+    exit $exit_code
+}
+
+fatal() {
+    echo $@
+    exit 1
+}
+
+get_last_successful_build_number() {
+    local builder_name="$1"
+
+    curl "https://build.webkit.org/api/v2/builders/$builder_name/builds?order=-number&limit=1&complete=true" 2>/dev/null | grep "number" | egrep -o "[0-9]+"
+}
+
+get_canonical_id_from_build_number() {
+    local builder_name="$1"
+    local build_number="$2"
+    local step_name="clean-and-update-working-directory"
+
+    curl "https://build.webkit.org/api/v2/builders/$builder_name/builds/$build_number/steps/$step_name" 2>/dev/null | egrep -m 1 -o "[0-9]+@main"
+}
+
+get_commit_from_canonical_id() {
+    local canonical_id="$1"
+    local next_commit
+
+    next_commit=$(git log | grep -m 1 -A 2 "$canonical_id" | grep commit | cut -d " " -f 2)
+    if [[ $? -eq 0 ]]; then
+        git log -1 --format="%H" ${next_commit}~
+        return 0
+    fi
+    return 1
+}
+
+update_and_move_to_main_branch() {
+    git reset --hard origin/main &>/dev/null || true
+    git fetch main &>/dev/null
+    git checkout main &>/dev/null
+    git pull &>/dev/null
+}
+
+restore_and_move_to_previous_branch() {
+    git checkout - &>/dev/null
+}
+
+is_webkit_repository() {
+    local dir="$1"
+    local url exit_code
+
+    pushd $dir &>/dev/null
+    url=$(git config --get remote.origin.url)
+    popd &>/dev/null
+
+    url=${url,,}
+    [[ "$url" == "https://github.com/webkit/webkit.git" || "$url" == "ssh://git@github.com:webkit/webkit.git" ]]
+}
+
+if ! is_webkit_repository $WEBKIT_CHECKOUT_DIR; then
+    usage 1
+fi
+
+build_number=$(get_last_successful_build_number "$BUILDER_NAME")
+canonical_id=$(get_canonical_id_from_build_number "$BUILDER_NAME" "$build_number")
+
+pushd $WEBKIT_CHECKOUT_DIR &>/dev/null
+update_and_move_to_main_branch
+commit=$(get_commit_from_canonical_id "$canonical_id")
+restore_and_move_to_previous_branch
+popd &>/dev/null
+
+echo "$commit"

--- a/wubkat/setup
+++ b/wubkat/setup
@@ -42,6 +42,21 @@ git remote prune origin || true
 git pull origin main || handle_tree_error "wubkat git pull"
 popd
 
+date
+
+echo Figuring out what revision to use.
+USE_REV=$(./last-successful-build-to-git-commit.sh -GTK-Linux-64-bit-Release-Ubuntu-LTS-Build $GIT_ROOT)
+echo Checking out last successfully built revision "${USE_REV}"
+
+date
+
+pushd $GIT_ROOT
+git checkout "${USE_REV}"
+popd
+echo Revision should now be checked out.
+
+date
+
 echo Generating blame information
 $MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT
 
@@ -64,18 +79,6 @@ date
 # Support for 22.04 seems to have been officially added in
 # https://searchfox.org/wubkat/commit/aa960b1a0c7b980efdbc66718239a449b5966a0c
 # so we're now using it directly again.
-# As noted above, this is disabled because it tries to install packages that
-# don't exist on ubuntu22.04 and so the command ends up not doing anything at
-# all, which is obviously not helpful.
 sudo $FILES_ROOT/Tools/gtk/install-dependencies
 
 date
-
-# WIP: Tentatively removing this gi-docgen hack since the ubuntu 22.04 support
-# may have fixed this.
-#
-# gi-docgen caused a failure at 99% completion for WebKit2WebExtension with a
-# non-helpful `xml.etree.ElementTree.ParseError: unclosed token: line 41073, column 6`
-# and we don't need that, so let's just turn gi-docgen into a no-op
-#sudo rm /usr/bin/gi-docgen
-#sudo ln -s /usr/bin/true /usr/bin/gi-docgen


### PR DESCRIPTION
All the hard work here was done by dpino at
https://gist.github.com/dpino/b324320652bb8b758acde123f9a3dbdc where this revision is sourced from.  We specifically are using: https://gist.githubusercontent.com/dpino/b324320652bb8b758acde123f9a3dbdc/raw/87d75cfe4ff8aa8a4d2fd7f86dfc507f18cd58fa/last-successful-build-to-git-commit.sh

I've annotated the script itself with equivalent information, but there is a potential for it to get lost if we update the script (although we should try not to).