### PR TITLE
Bug 1776522 - Move from ANALYSIS_DATA to SYM_INFO for context-menu.

### DIFF
--- a/mozilla-central/checks/inputs/analysis/xpidl/xpctest_params__def_testOctet__html
+++ b/mozilla-central/checks/inputs/analysis/xpidl/xpctest_params__def_testOctet__html
@@ -1,1 +1,1 @@
-filter-analysis js/xpconnect/tests/idl/xpctest_params.idl -k idl -i "testOctet"  | show-html | production-filter
+filter-analysis js/xpconnect/tests/idl/xpctest_params.idl -k idl -i "nsIXPCTestParams::testOctet"  | show-html | production-filter

--- a/mozilla-central/checks/inputs/analysis/xpidl/xpctest_params__def_testOctet__json
+++ b/mozilla-central/checks/inputs/analysis/xpidl/xpctest_params__def_testOctet__json
@@ -1,1 +1,1 @@
-filter-analysis js/xpconnect/tests/idl/xpctest_params.idl -k idl -i "testOctet"
+filter-analysis js/xpconnect/tests/idl/xpctest_params.idl -k idl -i "nsIXPCTestParams::testOctet"

--- a/mozilla-central/checks/snapshots/analysis/xpidl/check_glob@xpctest_params__def_testOctet__html.snap
+++ b/mozilla-central/checks/snapshots/analysis/xpidl/check_glob@xpctest_params__def_testOctet__html.snap
@@ -6,7 +6,7 @@ expression: "&aggr_str"
   <div role="cell"></div>
   <div role="cell"></div>
   <div role="cell" class="line-number" data-line-number="NORM"></div>
-  <code role="cell" class="source-line">  <span class="syn_reserved" >octet</span>                 <span class="syn_def syn_def" data-symbols="_ZN16nsIXPCTestParams9TestOctetEhPhS0_,_ZN16nsIXPCTestParams9TestOctetEhPhS0_,#testOctet" data-i="NORM">testOctet</span>(<span class="syn_reserved" >in</span> <span class="syn_reserved" >octet</span> a, <span class="syn_reserved" >inout</span> <span class="syn_reserved" >octet</span> b);
+  <code role="cell" class="source-line">  <span class="syn_reserved" >octet</span>                 <span class="syn_def" data-symbols="XPIDL_nsIXPCTestParams_testOctet">testOctet</span>(<span class="syn_reserved" >in</span> <span class="syn_reserved" >octet</span> a, <span class="syn_reserved" >inout</span> <span class="syn_reserved" >octet</span> b);
 </code>
 </div>
 

--- a/mozilla-central/checks/snapshots/analysis/xpidl/check_glob@xpctest_params__def_testOctet__json.snap
+++ b/mozilla-central/checks/snapshots/analysis/xpidl/check_glob@xpctest_params__def_testOctet__json.snap
@@ -7,28 +7,14 @@ expression: "&json_results"
     "loc": "24:24-33",
     "target": 1,
     "kind": "idl",
-    "pretty": "testOctet",
-    "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_"
+    "pretty": "nsIXPCTestParams::testOctet",
+    "sym": "XPIDL_nsIXPCTestParams_testOctet"
   },
   {
     "loc": "24:24-33",
     "source": 1,
     "syntax": "idl",
-    "pretty": "IDL C++ method testOctet",
-    "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_"
-  },
-  {
-    "loc": "24:24-33",
-    "source": 1,
-    "syntax": "idl",
-    "pretty": "IDL method testOctet",
-    "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_,#testOctet"
-  },
-  {
-    "loc": "24:24-33",
-    "target": 1,
-    "kind": "idl",
-    "pretty": "testOctet",
-    "sym": "#testOctet"
+    "pretty": "IDL method nsIXPCTestParams::testOctet",
+    "sym": "XPIDL_nsIXPCTestParams_testOctet"
   }
 ]


### PR DESCRIPTION
Identical changes to the tests repo where we needed to explicitly provide the full identifier name for XPIDL members now.