### PR TITLE
Stop trying to build glean

### DIFF
--- a/glean/build
+++ b/glean/build
@@ -5,5 +5,6 @@ set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
 pushd $GIT_ROOT
-RUSTFLAGS="-Z save-analysis" cargo +nightly check --all --target-dir=$OBJDIR || echo "WARNING: Glean build failed, see log for details"
+# Now that nightly rust doesn't support save-analysis, there's no point trying to compile glean.
+# RUSTFLAGS="-Z save-analysis" cargo +nightly check --all --target-dir=$OBJDIR || echo "WARNING: Glean build failed, see log for details"
 popd


### PR DESCRIPTION
This isn't working now anyway, because the nightly rust compiler has dropped support for save-analysis. And without that there's no point trying to compile.