### PR TITLE
No bug - make scip files optional on esr102

### DIFF
--- a/mozilla-esr102/setup
+++ b/mozilla-esr102/setup
@@ -19,6 +19,7 @@ $CONFIG_REPO/shared/checkout-gecko-repos.sh $REVISION_TREE "esr102" "$INDEXED_HG
 
 date
 
+export SCIP_OPTIONAL=yes
 $CONFIG_REPO/shared/fetch-tc-artifacts.sh $REVISION_TREE $INDEXED_HG_REV "$PREEXISTING_HG_REV"
 
 date

--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -105,7 +105,12 @@ for PLATFORM in linux64 macosx64 win64 android-armv7; do
     # Rust stdlib src and analysis data
     echo "${CURL} ${TC_PREFIX}/target.mozsearch-rust-stdlib.zip -o ${PLATFORM}.mozsearch-rust-stdlib.zip || true" >> downloads.lst
     # Rust scip files
-    echo "${CURL} ${TC_PREFIX}/target.mozsearch-scip-index.zip -o ${PLATFORM}.mozsearch-scip-index.zip" >> downloads.lst
+    if [[ -n $SCIP_OPTIONAL ]]; then
+        # ESR 102 doesn't have these files, so let it be optional there.
+        echo "${CURL} ${TC_PREFIX}/target.mozsearch-scip-index.zip -o ${PLATFORM}.mozsearch-scip-index.zip || true" >> downloads.lst
+    else
+        echo "${CURL} ${TC_PREFIX}/target.mozsearch-scip-index.zip -o ${PLATFORM}.mozsearch-scip-index.zip" >> downloads.lst
+    fi
     # Generated sources tarballs
     echo "${CURL} ${TC_PREFIX}/target.generated-files.tar.gz -o ${PLATFORM}.generated-files.tar.gz" >> downloads.lst
     # Manifest for dist/include entries


### PR DESCRIPTION
The scip downloads were only added in FF 109, and we run this code on ESR 102 which doesn't have the scip files. So let's make it optional to prevent getting warnings all the time.