### PR TITLE
Bug 1852405 - Perform semantic C++ indexing of LLVM

### DIFF
--- a/just-llvm.json
+++ b/just-llvm.json
@@ -1,0 +1,23 @@
+{
+    "mozsearch_path": "$MOZSEARCH_PATH",
+    "config_repo": "$CONFIG_REPO",
+    "default_tree": "llvm",
+    "instance_type": "t3.xlarge",
+
+    "trees": {
+      "llvm": {
+        "priority": 3,
+        "on_error": "continue",
+        "cache": "codesearch",
+        "index_path": "$WORKING/llvm",
+        "files_path": "$WORKING/llvm/git",
+        "git_path": "$WORKING/llvm/git",
+        "git_blame_path": "$WORKING/llvm/blame",
+        "github_repo": "https://github.com/llvm/llvm-project",
+        "objdir_path": "$WORKING/llvm/objdir",
+        "codesearch_path": "$WORKING/llvm/livegrep.idx",
+        "codesearch_port": 8082,
+        "scip_subtrees": {}
+      }
+    }
+  }

--- a/llvm/build
+++ b/llvm/build
@@ -4,3 +4,18 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
+date
+
+# Add the special clang flags.
+$MOZSEARCH_PATH/scripts/indexer-setup.py > $INDEX_ROOT/config
+. $INDEX_ROOT/config
+
+mkdir -p $OBJDIR
+
+cd $FILES_ROOT
+cmake -S llvm -B build -G Ninja -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=lld
+ninja -C build
+
+cd -
+
+date


### PR DESCRIPTION
This also adds a "just-llvm.json" configuration file along the lines of "just-mc.json" for the benefit of faster iteration if trying out C++ indexer improvements against a non-trivial codebase.  config4 is quite heavy-weight right now, so it's desirable to avoid building everything else.  Also LLVM potentially may make a faster C++ iteration target than mozilla-central in many cases since it can be triggered in a single go without needing to trigger a "try" job, etc.