### PR TITLE
Bug 1852405 - Build LLVM using an explicit objdir instead of "build" subdir.

### DIFF
--- a/llvm/build
+++ b/llvm/build
@@ -12,9 +12,9 @@ $MOZSEARCH_PATH/scripts/indexer-setup.py > $INDEX_ROOT/config
 
 mkdir -p $OBJDIR
 
-cd $FILES_ROOT
-cmake -S llvm -B build -G Ninja -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=lld
-ninja -C build
+cd $OBJDIR
+cmake -S $FILES_ROOT/llvm -B $OBJDIR -G Ninja -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=lld
+cmake --build .
 
 cd -
 


### PR DESCRIPTION
Instead of building into a "build" subdir, use the explicit $OBJDIR that searchfox expects.

This improves upon https://github.com/mozsearch/mozsearch-mozilla/pull/210