### PR TITLE
Bug 1859373 - Use scip-indexer for rust indexing, plus index the m-c python tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *~
+/mozilla-central/checks/explanations/

--- a/config1.json
+++ b/config1.json
@@ -17,7 +17,8 @@
       "hg_root": "https://hg.mozilla.org/projects/nss",
       "objdir_path": "$WORKING/nss/dist",
       "codesearch_path": "$WORKING/nss/livegrep.idx",
-      "codesearch_port": 8081
+      "codesearch_port": 8081,
+      "scip_subtrees": {}
     },
 
     "mozilla-central": {
@@ -34,7 +35,8 @@
       "wpt_root": "testing/web-platform",
       "objdir_path": "$WORKING/mozilla-central/objdir",
       "codesearch_path": "$WORKING/mozilla-central/livegrep.idx",
-      "codesearch_port": 8082
+      "codesearch_port": 8082,
+      "scip_subtrees": {}
     },
 
     "comm-central": {
@@ -49,7 +51,8 @@
       "hg_root": "https://hg.mozilla.org/comm-central",
       "objdir_path": "$WORKING/comm-central/objdir",
       "codesearch_path": "$WORKING/comm-central/livegrep.idx",
-      "codesearch_port": 8083
+      "codesearch_port": 8083,
+      "scip_subtrees": {}
     },
 
     "mozilla-mobile": {
@@ -61,7 +64,8 @@
       "git_path": "$WORKING/mozilla-mobile/git",
       "objdir_path": "$WORKING/mozilla-mobile/objdir",
       "codesearch_path": "$WORKING/mozilla-mobile/livegrep.idx",
-      "codesearch_port": 8084
+      "codesearch_port": 8084,
+      "scip_subtrees": {}
     }
   }
 }

--- a/config2.json
+++ b/config2.json
@@ -16,7 +16,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-beta",
       "objdir_path": "$WORKING/mozilla-beta/objdir",
       "codesearch_path": "$WORKING/mozilla-beta/livegrep.idx",
-      "codesearch_port": 8081
+      "codesearch_port": 8081,
+      "scip_subtrees": {}
     },
 
     "mozilla-release": {
@@ -31,7 +32,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-release",
       "objdir_path": "$WORKING/mozilla-release/objdir",
       "codesearch_path": "$WORKING/mozilla-release/livegrep.idx",
-      "codesearch_port": 8082
+      "codesearch_port": 8082,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr102": {
@@ -46,7 +48,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr102",
       "objdir_path": "$WORKING/mozilla-esr102/objdir",
       "codesearch_path": "$WORKING/mozilla-esr102/livegrep.idx",
-      "codesearch_port": 8083
+      "codesearch_port": 8083,
+      "scip_subtrees": {}
     },
 
     "comm-esr102": {
@@ -60,7 +63,8 @@
       "hg_root": "https://hg.mozilla.org/releases/comm-esr102",
       "objdir_path": "$WORKING/comm-esr102/objdir",
       "codesearch_path": "$WORKING/comm-esr102/livegrep.idx",
-      "codesearch_port": 8084
+      "codesearch_port": 8084,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr115": {
@@ -75,7 +79,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr115",
       "objdir_path": "$WORKING/mozilla-esr115/objdir",
       "codesearch_path": "$WORKING/mozilla-esr115/livegrep.idx",
-      "codesearch_port": 8085
+      "codesearch_port": 8085,
+      "scip_subtrees": {}
     },
 
     "comm-esr115": {
@@ -89,7 +94,8 @@
       "hg_root": "https://hg.mozilla.org/releases/comm-esr115",
       "objdir_path": "$WORKING/comm-esr115/objdir",
       "codesearch_path": "$WORKING/comm-esr115/livegrep.idx",
-      "codesearch_port": 8086
+      "codesearch_port": 8086,
+      "scip_subtrees": {}
     }
   }
 }

--- a/config3.json
+++ b/config3.json
@@ -16,7 +16,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr17",
       "objdir_path": "$WORKING/mozilla-esr17/objdir",
       "codesearch_path": "$WORKING/mozilla-esr17/livegrep.idx",
-      "codesearch_port": 8081
+      "codesearch_port": 8081,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr31": {
@@ -31,7 +32,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr31",
       "objdir_path": "$WORKING/mozilla-esr31/objdir",
       "codesearch_path": "$WORKING/mozilla-esr31/livegrep.idx",
-      "codesearch_port": 8082
+      "codesearch_port": 8082,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr45": {
@@ -46,7 +48,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr45",
       "objdir_path": "$WORKING/mozilla-esr45/objdir",
       "codesearch_path": "$WORKING/mozilla-esr45/livegrep.idx",
-      "codesearch_port": 8083
+      "codesearch_port": 8083,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr60": {
@@ -75,7 +78,8 @@
       "hg_root": "https://hg.mozilla.org/releases/comm-esr60",
       "objdir_path": "$WORKING/comm-esr60/objdir",
       "codesearch_path": "$WORKING/comm-esr60/livegrep.idx",
-      "codesearch_port": 8085
+      "codesearch_port": 8085,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr68": {
@@ -90,7 +94,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr68",
       "objdir_path": "$WORKING/mozilla-esr68/objdir",
       "codesearch_path": "$WORKING/mozilla-esr68/livegrep.idx",
-      "codesearch_port": 8086
+      "codesearch_port": 8086,
+      "scip_subtrees": {}
     },
 
     "comm-esr68": {
@@ -104,7 +109,8 @@
       "hg_root": "https://hg.mozilla.org/releases/comm-esr68",
       "objdir_path": "$WORKING/comm-esr68/objdir",
       "codesearch_path": "$WORKING/comm-esr68/livegrep.idx",
-      "codesearch_port": 8087
+      "codesearch_port": 8087,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr78": {
@@ -118,7 +124,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr78",
       "objdir_path": "$WORKING/mozilla-esr78/objdir",
       "codesearch_path": "$WORKING/mozilla-esr78/livegrep.idx",
-      "codesearch_port": 8088
+      "codesearch_port": 8088,
+      "scip_subtrees": {}
     },
 
     "comm-esr78": {
@@ -132,7 +139,8 @@
       "hg_root": "https://hg.mozilla.org/releases/comm-esr78",
       "objdir_path": "$WORKING/comm-esr78/objdir",
       "codesearch_path": "$WORKING/comm-esr78/livegrep.idx",
-      "codesearch_port": 8089
+      "codesearch_port": 8089,
+      "scip_subtrees": {}
     },
 
     "mozilla-esr91": {
@@ -147,7 +155,8 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-esr91",
       "objdir_path": "$WORKING/mozilla-esr91/objdir",
       "codesearch_path": "$WORKING/mozilla-esr91/livegrep.idx",
-      "codesearch_port": 8090
+      "codesearch_port": 8090,
+      "scip_subtrees": {}
     },
 
     "comm-esr91": {
@@ -161,7 +170,8 @@
       "hg_root": "https://hg.mozilla.org/releases/comm-esr91",
       "objdir_path": "$WORKING/comm-esr91/objdir",
       "codesearch_path": "$WORKING/comm-esr91/livegrep.idx",
-      "codesearch_port": 8091
+      "codesearch_port": 8091,
+      "scip_subtrees": {}
     }
   }
 }

--- a/config4.json
+++ b/config4.json
@@ -13,7 +13,8 @@
       "git_path": "$WORKING/l10n/git",
       "objdir_path": "$WORKING/l10n/objdir",
       "codesearch_path": "$WORKING/l10n/livegrep.idx",
-      "codesearch_port": 8081
+      "codesearch_port": 8081,
+      "scip_subtrees": {}
     },
 
     "llvm": {
@@ -27,7 +28,8 @@
       "github_repo": "https://github.com/llvm/llvm-project",
       "objdir_path": "$WORKING/llvm/objdir",
       "codesearch_path": "$WORKING/llvm/livegrep.idx",
-      "codesearch_port": 8082
+      "codesearch_port": 8082,
+      "scip_subtrees": {}
     },
 
     "mingw": {
@@ -40,7 +42,8 @@
       "git_blame_path": "$WORKING/mingw/blame",
       "objdir_path": "$WORKING/mingw/objdir",
       "codesearch_path": "$WORKING/mingw/livegrep.idx",
-      "codesearch_port": 8083
+      "codesearch_port": 8083,
+      "scip_subtrees": {}
     },
 
     "mingw-moz": {
@@ -53,7 +56,8 @@
       "git_blame_path": "$WORKING/mingw-moz/blame",
       "objdir_path": "$WORKING/mingw-moz/objdir",
       "codesearch_path": "$WORKING/mingw-moz/livegrep.idx",
-      "codesearch_port": 8084
+      "codesearch_port": 8084,
+      "scip_subtrees": {}
     },
 
     "rust": {
@@ -68,7 +72,8 @@
       "github_repo": "https://github.com/rust-lang/rust",
       "objdir_path": "$WORKING/rust/objdir",
       "codesearch_path": "$WORKING/rust/livegrep.idx",
-      "codesearch_port": 8085
+      "codesearch_port": 8085,
+      "scip_subtrees": {}
     },
 
     "whatwg-html": {
@@ -82,7 +87,8 @@
       "github_repo": "https://github.com/whatwg/html",
       "objdir_path": "$WORKING/whatwg-html/objdir",
       "codesearch_path": "$WORKING/whatwg-html/livegrep.idx",
-      "codesearch_port": 8086
+      "codesearch_port": 8086,
+      "scip_subtrees": {}
     },
 
     "mozilla-build": {
@@ -96,7 +102,8 @@
       "hg_root": "https://hg.mozilla.org/mozilla-build/",
       "objdir_path": "$WORKING/mozilla-build/dist",
       "codesearch_path": "$WORKING/mozilla-build/livegrep.idx",
-      "codesearch_port": 8087
+      "codesearch_port": 8087,
+      "scip_subtrees": {}
     },
 
     "glean": {
@@ -110,7 +117,8 @@
       "github_repo": "https://github.com/mozilla/glean",
       "objdir_path": "$WORKING/glean/objdir",
       "codesearch_path": "$WORKING/glean/livegrep.idx",
-      "codesearch_port": 8088
+      "codesearch_port": 8088,
+      "scip_subtrees": {}
     },
 
     "version-control-tools": {
@@ -124,7 +132,8 @@
       "hg_root": "https://hg.mozilla.org/hgcustom/version-control-tools",
       "objdir_path": "$WORKING/version-control-tools/objdir",
       "codesearch_path": "$WORKING/version-control-tools/livegrep.idx",
-      "codesearch_port": 8089
+      "codesearch_port": 8089,
+      "scip_subtrees": {}
     },
 
     "ecma262": {
@@ -138,7 +147,8 @@
       "github_repo": "https://github.com/tc39/ecma262/",
       "objdir_path": "$WORKING/ecma262/objdir",
       "codesearch_path": "$WORKING/ecma262/livegrep.idx",
-      "codesearch_port": 8090
+      "codesearch_port": 8090,
+      "scip_subtrees": {}
     },
 
     "kaios": {
@@ -152,7 +162,8 @@
       "hg_root": "https://hg.mozilla.org/projects/kaios/",
       "objdir_path": "$WORKING/kaios/objdir",
       "codesearch_path": "$WORKING/kaios/livegrep.idx",
-      "codesearch_port": 8091
+      "codesearch_port": 8091,
+      "scip_subtrees": {}
     },
 
     "mozilla-vpn-client": {
@@ -166,7 +177,8 @@
       "git_blame_path": "$WORKING/mozilla-vpn-client/blame",
       "objdir_path": "$WORKING/mozilla-vpn-client/objdir",
       "codesearch_path": "$WORKING/mozilla-vpn-client/livegrep.idx",
-      "codesearch_port": 8092
+      "codesearch_port": 8092,
+      "scip_subtrees": {}
     },
 
     "mozilla-elm": {
@@ -180,7 +192,8 @@
       "hg_root": "https://hg.mozilla.org/projects/elm",
       "objdir_path": "$WORKING/mozilla-elm/objdir",
       "codesearch_path": "$WORKING/mozilla-elm/livegrep.idx",
-      "codesearch_port": 8093
+      "codesearch_port": 8093,
+      "scip_subtrees": {}
     },
 
     "mozilla-cedar": {
@@ -194,7 +207,8 @@
       "hg_root": "https://hg.mozilla.org/projects/cedar",
       "objdir_path": "$WORKING/mozilla-cedar/objdir",
       "codesearch_path": "$WORKING/mozilla-cedar/livegrep.idx",
-      "codesearch_port": 8094
+      "codesearch_port": 8094,
+      "scip_subtrees": {}
     }
   }
 }

--- a/config5.json
+++ b/config5.json
@@ -16,7 +16,8 @@
         "github_repo": "https://github.com/WebKit/Webkit",
         "objdir_path": "$WORKING/wubkat/objdir",
         "codesearch_path": "$WORKING/wubkat/livegrep.idx",
-        "codesearch_port": 8081
+        "codesearch_port": 8081,
+        "scip_subtrees": {}
       }
     }
   }

--- a/just-mc.json
+++ b/just-mc.json
@@ -20,7 +20,12 @@
       "objdir_path": "$WORKING/mozilla-central/objdir",
       "codesearch_path": "$WORKING/mozilla-central/livegrep.idx",
       "codesearch_port": 8082,
-      "scip_subtrees": {}
+      "scip_subtrees": {
+        "python": {
+          "scip_index_path": "$WORKING/mozilla-central/python.scip",
+          "subtree_root": "python"
+        }
+      }
     }
   }
 }

--- a/just-mc.json
+++ b/just-mc.json
@@ -19,7 +19,8 @@
       "wpt_root": "testing/web-platform",
       "objdir_path": "$WORKING/mozilla-central/objdir",
       "codesearch_path": "$WORKING/mozilla-central/livegrep.idx",
-      "codesearch_port": 8082
+      "codesearch_port": 8082,
+      "scip_subtrees": {}
     }
   }
 }

--- a/mozilla-central/build
+++ b/mozilla-central/build
@@ -11,3 +11,13 @@ $CONFIG_REPO/shared/process-gecko-analysis.sh
 popd
 
 date
+
+# Analyze the unified python corpus
+pushd $GIT_ROOT/python
+# Absolute paths aren't treated as absolute but instead concatenated, so we need
+# to use just a filename and then move it after.
+rtx exec nodejs@18 -- scip-python index --project-name python --output python.scip
+mv python.scip $INDEX_ROOT
+popd
+
+date

--- a/shared/process-tc-artifacts.sh
+++ b/shared/process-tc-artifacts.sh
@@ -204,19 +204,22 @@ find objdir-$PLATFORM -type f -name "*.json" | parallel -q --halt now,fail=1 sed
 
 date
 
-# Run the rust analysis here.
+
+## Run the SCIP analysis here.
+
 # Note that we specify "objdir" as the objdir_src for __GENERATED__ for source
 # purposes because the only source that's in objdir-$PLATFORM is the rustlib
 # source, and that's covered by the next line which does use objdir-$PLATFORM.
 # (We also copy that source into ojbdir, but that action is racey.  See the
 # comments where we perform the copying.)
 export RUST_LOG=info
-$MOZSEARCH_PATH/scripts/rust-analyze.sh \
+$MOZSEARCH_PATH/tools/target/release/scip-indexer \
   "$CONFIG_FILE" \
   "$TREE_NAME" \
-  "objdir-$PLATFORM" \
-  "generated-$PLATFORM" \
-  "$INDEX_ROOT/analysis-$PLATFORM"
+  --subtree-name "rust" \
+  --subtree-root "." \
+  --platform "$PLATFORM" \
+  "objdir-$PLATFORM/rust.scip"
 
 date
 


### PR DESCRIPTION
A change to the config file format in https://github.com/mozsearch/mozsearch/pull/663 requires all the config files to have a scip_subtrees JSON property.  This adds that plus replaces use of rust-indexer with scip-indexer.  Also we'll index some python stuff in m-c.