### PR TITLE
Use java/kotlin semanticdb content from mozilla-central

### DIFF
--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -40,6 +40,7 @@ if [[ -n $PREEXISTING_HG_REV && $PREEXISTING_HG_REV != $INDEXED_HG_REV ]]; then
     rm -f *.mozsearch-rust.zip
     rm -f *.mozsearch-rust-stdlib.zip
     rm -f *.mozsearch-scip-index.zip
+    rm -f *.mozsearch-java-index.zip
     rm -f *.generated-files.tar.gz
     rm -f *.distinclude.map
 fi
@@ -115,6 +116,8 @@ for PLATFORM in linux64 macosx64 win64 android-armv7 ${IOS}; do
     else
         echo "${CURL} ${TC_PREFIX}/target.mozsearch-scip-index.zip -o ${PLATFORM}.mozsearch-scip-index.zip" >> downloads.lst
     fi
+    # Java scip files, only android builds will have one, so make it optional
+    echo "${CURL} ${TC_PREFIX}/target.mozsearch-java-index.zip -o ${PLATFORM}.mozsearch-java-index.zip || true" >> downloads.lst
     # Generated sources tarballs
     echo "${CURL} ${TC_PREFIX}/target.generated-files.tar.gz -o ${PLATFORM}.generated-files.tar.gz" >> downloads.lst
     # Manifest for dist/include entries

--- a/shared/process-tc-artifacts.sh
+++ b/shared/process-tc-artifacts.sh
@@ -54,6 +54,14 @@ fi
 
 date
 
+if [ -f "$PLATFORM.mozsearch-java-index.zip" ]; then
+  mkdir -p objdir-$PLATFORM/java_index
+  unzip -q $PLATFORM.mozsearch-java-index.zip -d objdir-$PLATFORM/java_index
+  scip-java index-semanticdb --no-emit-inverse-relationships --output=objdir-$PLATFORM/java.scip objdir-$PLATFORM/java_index
+fi
+
+date
+
 # Unpack generated sources tarballs into platform-specific folder
 mkdir -p generated-$PLATFORM
 tar -x -z -C generated-$PLATFORM -f $PLATFORM.generated-files.tar.gz
@@ -222,6 +230,19 @@ $MOZSEARCH_PATH/tools/target/release/scip-indexer \
   "objdir-$PLATFORM/rust.scip"
 
 date
+
+# Only android builds will have a java.scip
+if [ -f "objdir-$PLATFORM/java.scip" ]; then
+  $MOZSEARCH_PATH/tools/target/release/scip-indexer \
+    "$CONFIG_FILE" \
+    "$TREE_NAME" \
+    --subtree-name "java" \
+    --subtree-root "." \
+    --platform "$PLATFORM" \
+    "objdir-$PLATFORM/java.scip"
+
+  date
+fi
 
 # Process the dist/include manifest and normalize away the taskcluster paths
 dos2unix --quiet --force $PLATFORM.distinclude.map  # need --force because of \x1f column separator chars in the file


### PR DESCRIPTION
Up on dev.searchfox.org for testing already, see eg. [this search for org.mozilla.geckoview.GeckoSession.PromptDelegate.AutocompleteRequest](https://dev.searchfox.org/mozilla-central/search?q=symbol:S_java_java_org%2Fmozilla%2Fgeckoview%2FGeckoSession%23PromptDelegate%23AutocompleteRequest%23) which returns Java and Kotlin files.

Marking as draft until I get the relevant changes reviewed and merged into mozilla-central.