### PR TITLE
Bug 1878998 - Add comm-beta and comm-release to Searchfox indexing

### DIFF
--- a/comm-beta/build
+++ b/comm-beta/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+

--- a/comm-beta/reblame
+++ b/comm-beta/reblame
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+$CONFIG_REPO/shared/rebuild-blame.sh --tarball-base comm-beta $*

--- a/comm-beta/setup
+++ b/comm-beta/setup
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Downloading comm-beta repo
+pushd $INDEX_ROOT
+if [ -d "git" ]
+then
+    echo "Found pre-existing folder; skipping re-download."
+else
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/comm-beta.tar
+    tar xf comm-beta.tar
+    rm comm-beta.tar
+fi
+popd
+
+date
+
+echo Downloading comm-beta blame.
+pushd $INDEX_ROOT
+if [ -d "blame" ]
+then
+    echo "Found pre-existing blame folder; skipping re-download."
+else
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/comm-beta-blame.tar
+    tar xf comm-beta-blame.tar
+    rm comm-beta-blame.tar
+fi
+popd
+
+date
+
+echo Updating git
+pushd $GIT_ROOT
+git pull
+popd
+
+echo Generating blame information
+$MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT
+
+date

--- a/comm-beta/upload
+++ b/comm-beta/upload
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Uploading comm-beta
+pushd $INDEX_ROOT
+$CONFIG_REPO/shared/git-maintenance.sh ./git
+tar cf comm-beta.tar git
+$AWS_ROOT/upload.py $INDEX_ROOT/comm-beta.tar searchfox.repositories comm-beta.tar
+rm comm-beta.tar
+popd
+
+date
+
+echo Uploading comm-beta blame
+pushd $INDEX_ROOT
+$CONFIG_REPO/shared/git-maintenance.sh ./blame
+tar cf comm-beta-blame.tar blame
+$AWS_ROOT/upload.py $INDEX_ROOT/comm-beta-blame.tar searchfox.repositories comm-beta-blame.tar
+rm comm-beta-blame.tar
+popd
+
+date

--- a/comm-release/build
+++ b/comm-release/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+

--- a/comm-release/reblame
+++ b/comm-release/reblame
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+$CONFIG_REPO/shared/rebuild-blame.sh --tarball-base comm-release $*

--- a/comm-release/setup
+++ b/comm-release/setup
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Downloading comm-release repo
+pushd $INDEX_ROOT
+if [ -d "git" ]
+then
+    echo "Found pre-existing folder; skipping re-download."
+else
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/comm-release.tar
+    tar xf comm-release.tar
+    rm comm-release.tar
+fi
+popd
+
+date
+
+echo Downloading comm-release blame.
+pushd $INDEX_ROOT
+if [ -d "blame" ]
+then
+    echo "Found pre-existing blame folder; skipping re-download."
+else
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/comm-release-blame.tar
+    tar xf comm-release-blame.tar
+    rm comm-release-blame.tar
+fi
+popd
+
+date
+
+echo Updating git
+pushd $GIT_ROOT
+git pull
+popd
+
+echo Generating blame information
+$MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT
+
+date

--- a/comm-release/upload
+++ b/comm-release/upload
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+date
+
+echo Uploading comm-release
+pushd $INDEX_ROOT
+$CONFIG_REPO/shared/git-maintenance.sh ./git
+tar cf comm-release.tar git
+$AWS_ROOT/upload.py $INDEX_ROOT/comm-release.tar searchfox.repositories comm-release.tar
+rm comm-release.tar
+popd
+
+date
+
+echo Uploading comm-release blame
+pushd $INDEX_ROOT
+$CONFIG_REPO/shared/git-maintenance.sh ./blame
+tar cf comm-release-blame.tar blame
+$AWS_ROOT/upload.py $INDEX_ROOT/comm-release-blame.tar searchfox.repositories comm-release-blame.tar
+rm comm-release-blame.tar
+popd
+
+date

--- a/config2.json
+++ b/config2.json
@@ -20,6 +20,21 @@
       "scip_subtrees": {}
     },
 
+    "comm-beta": {
+      "priority": 20,
+      "on_error": "continue",
+      "cache": "codesearch",
+      "index_path": "$WORKING/comm-beta",
+      "files_path": "$WORKING/comm-beta/git",
+      "git_path": "$WORKING/comm-beta/git",
+      "git_blame_path": "$WORKING/comm-beta/blame",
+      "hg_root": "https://hg.mozilla.org/releases/comm-beta",
+      "objdir_path": "$WORKING/comm-beta/objdir",
+      "codesearch_path": "$WORKING/comm-beta/livegrep.idx",
+      "codesearch_port": 8082,
+      "scip_subtrees": {}
+    },
+
     "mozilla-release": {
       "priority": 110,
       "on_error": "continue",
@@ -33,6 +48,21 @@
       "objdir_path": "$WORKING/mozilla-release/objdir",
       "codesearch_path": "$WORKING/mozilla-release/livegrep.idx",
       "codesearch_port": 8083,
+      "scip_subtrees": {}
+    },
+
+    "comm-release": {
+      "priority": 15,
+      "on_error": "continue",
+      "cache": "codesearch",
+      "index_path": "$WORKING/comm-release",
+      "files_path": "$WORKING/comm-release/git",
+      "git_path": "$WORKING/comm-release/git",
+      "git_blame_path": "$WORKING/comm-release/blame",
+      "hg_root": "https://hg.mozilla.org/releases/comm-release",
+      "objdir_path": "$WORKING/comm-release/objdir",
+      "codesearch_path": "$WORKING/comm-release/livegrep.idx",
+      "codesearch_port": 8084,
       "scip_subtrees": {}
     },
 

--- a/config2.json
+++ b/config2.json
@@ -32,38 +32,7 @@
       "hg_root": "https://hg.mozilla.org/releases/mozilla-release",
       "objdir_path": "$WORKING/mozilla-release/objdir",
       "codesearch_path": "$WORKING/mozilla-release/livegrep.idx",
-      "codesearch_port": 8082,
-      "scip_subtrees": {}
-    },
-
-    "mozilla-esr102": {
-      "priority": 20,
-      "on_error": "continue",
-      "cache": "codesearch",
-      "index_path": "$WORKING/mozilla-esr102",
-      "files_path": "$WORKING/mozilla-esr102/git",
-      "git_path": "$WORKING/mozilla-esr102/git",
-      "git_blame_path": "$WORKING/mozilla-esr102/blame",
-      "github_repo": "https://github.com/mozilla/gecko-dev",
-      "hg_root": "https://hg.mozilla.org/releases/mozilla-esr102",
-      "objdir_path": "$WORKING/mozilla-esr102/objdir",
-      "codesearch_path": "$WORKING/mozilla-esr102/livegrep.idx",
       "codesearch_port": 8083,
-      "scip_subtrees": {}
-    },
-
-    "comm-esr102": {
-      "priority": 5,
-      "on_error": "continue",
-      "cache": "codesearch",
-      "index_path": "$WORKING/comm-esr102",
-      "files_path": "$WORKING/comm-esr102/git",
-      "git_path": "$WORKING/comm-esr102/git",
-      "git_blame_path": "$WORKING/comm-esr102/blame",
-      "hg_root": "https://hg.mozilla.org/releases/comm-esr102",
-      "objdir_path": "$WORKING/comm-esr102/objdir",
-      "codesearch_path": "$WORKING/comm-esr102/livegrep.idx",
-      "codesearch_port": 8084,
       "scip_subtrees": {}
     },
 
@@ -97,5 +66,6 @@
       "codesearch_port": 8086,
       "scip_subtrees": {}
     }
+
   }
 }

--- a/config3.json
+++ b/config3.json
@@ -69,7 +69,7 @@
     },
 
     "comm-esr60": {
-      "priority": 10,
+      "priority": 3,
       "on_error": "continue",
       "cache": "codesearch",
       "index_path": "$WORKING/comm-esr60",
@@ -100,7 +100,7 @@
     },
 
     "comm-esr68": {
-      "priority": 10,
+      "priority": 3,
       "on_error": "continue",
       "cache": "codesearch",
       "index_path": "$WORKING/comm-esr68",
@@ -130,7 +130,7 @@
     },
 
     "comm-esr78": {
-      "priority": 10,
+      "priority": 3,
       "on_error": "continue",
       "cache": "codesearch",
       "index_path": "$WORKING/comm-esr78",
@@ -161,7 +161,7 @@
     },
 
     "comm-esr91": {
-      "priority": 4,
+      "priority": 3,
       "on_error": "continue",
       "cache": "codesearch",
       "index_path": "$WORKING/comm-esr91",
@@ -172,6 +172,37 @@
       "objdir_path": "$WORKING/comm-esr91/objdir",
       "codesearch_path": "$WORKING/comm-esr91/livegrep.idx",
       "codesearch_port": 8091,
+      "scip_subtrees": {}
+    },
+
+    "mozilla-esr102": {
+      "priority": 10,
+      "on_error": "continue",
+      "cache": "codesearch",
+      "index_path": "$WORKING/mozilla-esr102",
+      "files_path": "$WORKING/mozilla-esr102/git",
+      "git_path": "$WORKING/mozilla-esr102/git",
+      "git_blame_path": "$WORKING/mozilla-esr102/blame",
+      "github_repo": "https://github.com/mozilla/gecko-dev",
+      "hg_root": "https://hg.mozilla.org/releases/mozilla-esr102",
+      "objdir_path": "$WORKING/mozilla-esr102/objdir",
+      "codesearch_path": "$WORKING/mozilla-esr102/livegrep.idx",
+      "codesearch_port": 8092,
+      "scip_subtrees": {}
+    },
+
+    "comm-esr102": {
+      "priority": 3,
+      "on_error": "continue",
+      "cache": "codesearch",
+      "index_path": "$WORKING/comm-esr102",
+      "files_path": "$WORKING/comm-esr102/git",
+      "git_path": "$WORKING/comm-esr102/git",
+      "git_blame_path": "$WORKING/comm-esr102/blame",
+      "hg_root": "https://hg.mozilla.org/releases/comm-esr102",
+      "objdir_path": "$WORKING/comm-esr102/objdir",
+      "codesearch_path": "$WORKING/comm-esr102/livegrep.idx",
+      "codesearch_port": 8093,
       "scip_subtrees": {}
     }
   }

--- a/help.html
+++ b/help.html
@@ -79,7 +79,9 @@ subdirectories (i.e., <code>*</code> does not match <code>/</code>).
        <tr><td><a href="/mozilla-elm/source/">mozilla-elm</a></td>          <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-cedar/source/">mozilla-cedar</a></td>      <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-beta/source/">mozilla-beta</a></td>        <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
+       <tr><td><a href="/comm-beta/source/">comm-beta</a></td>              <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       </tr>
        <tr><td><a href="/mozilla-release/source/">mozilla-release</a></td>  <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
+       <tr><td><a href="/comm-release/source/">comm-esr115</a></td>         <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       </tr>
        <tr><td><a href="/mozilla-esr115/source/">mozilla-esr115</a></td>    <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/comm-esr115/source/">comm-esr115</a></td>          <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       </tr>
        <tr><td><a href="/mozilla-esr102/source/">mozilla-esr102</a></td>    <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       </tr>


### PR DESCRIPTION
Thunderbird is moving to a monthly release schedule the same as Firefox's. Part of this has been to revive the comm-release repository.
This patch adds comm-beta and comm-release to Searchfox in the same manner as comm-esr115 (no mozilla/ subtree).