### PR TITLE
graphviz: Remove submodule steps

### DIFF
--- a/graphviz/setup
+++ b/graphviz/setup
@@ -37,8 +37,6 @@ date
 echo Updating git
 pushd $GIT_ROOT
 git pull origin main
-# graphviz uses submodules
-git submodule update --init --recursive
 
 popd
 


### PR DESCRIPTION
The Graphviz submodules are only relevant to users building on Windows platforms.