### PR TITLE
Revert "Avoid warnings about missing ios on non-cedar branches"

### DIFF
--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -83,11 +83,7 @@ echo "${CURL} ${TC_REV_PREFIX}.source.manifest-upload/artifacts/public/manifests
 # patches, making stale data potentially very misleading.  See Bug 1677903 for
 # more discussion.
 echo "${CURL} ${TC_TASK}/project.relman.code-coverage.production.repo.${REVISION_TREE}.${INDEXED_HG_REV}/artifacts/public/code-coverage-report.json -o code-coverage-report.json || true" >> downloads.lst
-IOS=
-if [ ${REVISION_TREE} = cedar ]; then
-    IOS=ios
-fi
-for PLATFORM in linux64 macosx64 win64 android-armv7 ${IOS}; do
+for PLATFORM in linux64 macosx64 win64 android-armv7 ios; do
     TC_PREFIX="${TC_REV_PREFIX}.firefox.${PLATFORM}-searchfox-debug/artifacts/public/build"
     # First check that the searchfox job exists for the platform and revision we want. Otherwise emit a warning and skip it. This
     # file is small so it's cheap to download as a check that the analysis data for the platform exists.


### PR DESCRIPTION
This reverts commit d8202392c2847c1e01d59cb34a5608f621312f85.

Now that mozilla-central has ios searchfox tasks, we shouldn't need to exclude those.