### PR TITLE
Exclude WPT from HTML indexing

### DIFF
--- a/comm-central/repo_files.py
+++ b/comm-central/repo_files.py
@@ -17,3 +17,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/kaios/repo_files.py
+++ b/kaios/repo_files.py
@@ -2,3 +2,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-beta/repo_files.py
+++ b/mozilla-beta/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-cedar/repo_files.py
+++ b/mozilla-cedar/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-central/repo_files.py
+++ b/mozilla-central/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-elm/repo_files.py
+++ b/mozilla-elm/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-esr102/repo_files.py
+++ b/mozilla-esr102/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-esr115/repo_files.py
+++ b/mozilla-esr115/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-esr17/repo_files.py
+++ b/mozilla-esr17/repo_files.py
@@ -8,6 +8,11 @@ def filter_js(path):
         return False
     return True
 
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True
+
 def filter_idl(path):
     # ESR17 doesn't even have an XPIDL parser we'll recognize but let's bypass
     # trying to use a modern one.

--- a/mozilla-esr31/repo_files.py
+++ b/mozilla-esr31/repo_files.py
@@ -8,6 +8,11 @@ def filter_js(path):
         return False
     return True
 
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True
+
 def filter_idl(path):
     # ESR31 doesn't even have an XPIDL parser we'll recognize but let's bypass
     # trying to use a modern one.

--- a/mozilla-esr45/repo_files.py
+++ b/mozilla-esr45/repo_files.py
@@ -8,6 +8,11 @@ def filter_js(path):
         return False
     return True
 
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True
+
 def filter_idl(path):
     # ESR45's XPIDL parser is python2 only
     return False

--- a/mozilla-esr60/repo_files.py
+++ b/mozilla-esr60/repo_files.py
@@ -8,6 +8,11 @@ def filter_js(path):
         return False
     return True
 
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True
+
 def filter_idl(path):
     # ESR60's XPIDL parser is python2 only
     return False

--- a/mozilla-esr68/repo_files.py
+++ b/mozilla-esr68/repo_files.py
@@ -8,6 +8,11 @@ def filter_js(path):
         return False
     return True
 
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True
+
 def filter_idl(path):
     # ESR68's XPIDL parser is python2 only
     return False

--- a/mozilla-esr78/repo_files.py
+++ b/mozilla-esr78/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-esr91/repo_files.py
+++ b/mozilla-esr91/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True

--- a/mozilla-release/repo_files.py
+++ b/mozilla-release/repo_files.py
@@ -7,3 +7,8 @@ def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False
     return True
+
+def filter_html(path):
+    if 'testing/web-platform/' in path:
+        return False
+    return True


### PR DESCRIPTION
Given there are so many HTML files in WPT, and the main purpose here for indexing HTML is to linkify chrome/resource URLs, which won't appear in WPT files, I'll exclude them for now.
We can revisit this once the crossref gets chunked and parallelized, and made capable of handling more files with less RAM usage