### PR TITLE
Add ignore_missing_path_prefixes config for wubkat and graphviz

### DIFF
--- a/config5.json
+++ b/config5.json
@@ -15,6 +15,9 @@
         "git_blame_path": "$WORKING/wubkat/blame",
         "github_repo": "https://github.com/WebKit/Webkit",
         "objdir_path": "$WORKING/wubkat/objdir",
+        "ignore_missing_path_prefixes": [
+          "$WORKING/wubkat/objdir/CMakeFiles/CMakeTmp/"
+        ],
         "codesearch_path": "$WORKING/wubkat/livegrep.idx",
         "codesearch_port": 8081,
         "scip_subtrees": {}
@@ -29,6 +32,12 @@
         "git_blame_path": "$WORKING/graphviz/blame",
         "github_repo": "https://gitlab.com/graphviz/graphviz/-",
         "objdir_path": "$WORKING/graphviz/objdir",
+        "ignore_missing_path_prefixes": [
+          "$WORKING/graphviz/objdir/conftest",
+          "$WORKING/graphviz/objdir/libltdl/.libs/libltdlcS.c",
+          "$WORKING/graphviz/objdir/libltdl/confdefs.h",
+          "$WORKING/graphviz/objdir/libltdl/conftest"
+        ],
         "codesearch_path": "$WORKING/graphviz/livegrep.idx",
         "codesearch_port": 8082,
         "scip_subtrees": {}


### PR DESCRIPTION
depends on https://github.com/mozsearch/mozsearch/pull/736