### PR TITLE
Bug 1899073 - Add ignore_missing_path_prefixes config for llvm

### DIFF
--- a/config4.json
+++ b/config4.json
@@ -27,6 +27,9 @@
       "git_blame_path": "$WORKING/llvm/blame",
       "github_repo": "https://github.com/llvm/llvm-project",
       "objdir_path": "$WORKING/llvm/objdir",
+      "ignore_missing_path_prefixes": [
+        "$WORKING/llvm/objdir/CMakeFiles/CMakeTmp/"
+      ],
       "codesearch_path": "$WORKING/llvm/livegrep.idx",
       "codesearch_port": 8082,
       "scip_subtrees": {}


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1899073