### PR TITLE
Bug 1899642 - Use ld-wrapper, and fix git URL

### DIFF
--- a/config5.json
+++ b/config5.json
@@ -30,7 +30,7 @@
         "files_path": "$WORKING/graphviz/git",
         "git_path": "$WORKING/graphviz/git",
         "git_blame_path": "$WORKING/graphviz/blame",
-        "github_repo": "https://gitlab.com/graphviz/graphviz/-",
+        "github_repo": "https://gitlab.com/graphviz/graphviz.git",
         "objdir_path": "$WORKING/graphviz/objdir",
         "ignore_missing_path_prefixes": [
           "$WORKING/graphviz/objdir/conftest",

--- a/graphviz/build
+++ b/graphviz/build
@@ -7,13 +7,10 @@ set -o pipefail # Check all commands in a pipeline
 date
 
 # Add the special clang flags.
-$MOZSEARCH_PATH/scripts/indexer-setup.py > $INDEX_ROOT/config
+# See $MOZSEARCH_PATH/scripts/ld-wrapper for WRAPPED_LD and --use-ld-wrapper.
+export WRAPPED_LD=ld
+$MOZSEARCH_PATH/scripts/indexer-setup.py --use-ld-wrapper > $INDEX_ROOT/config
 . $INDEX_ROOT/config
-# Trying to make libtool happy since automake is having us use our CC and all
-# its flags and if we use the default of "ld" we end up with it complaining
-# about "-load" because it doesn't understand the "-Xclang" syntax that precedes
-# it.
-export LD=lld
 
 rm -rf $OBJDIR
 mkdir -p $OBJDIR

--- a/graphviz/setup
+++ b/graphviz/setup
@@ -18,6 +18,10 @@ else
 fi
 popd
 
+# Temporary fix for the git url.
+# This can be deleted once this fix is reflected to the uploaded tarball.
+sed -i -e 's|https://gitlab.com/graphviz/graphviz$|https://gitlab.com/graphviz/graphviz.git|' $GIT_ROOT/.git/config
+
 date
 
 echo Downloading graphviz blame.


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1899642
depends on https://github.com/mozsearch/mozsearch/pull/741

This does:
  * use ld-wrapper added by https://github.com/mozsearch/mozsearch/pull/741
  * fix the git URL, which had been causing the redirection warning