### PR TITLE
Bug 1416899 - Update WebIDL filters to handle tools/ts, missed dirs

### DIFF
--- a/mozilla-beta/repo_files.py
+++ b/mozilla-beta/repo_files.py
@@ -10,6 +10,8 @@ def filter_webidl(path):
         return False
     if 'dom/webidl/MozApplicationEvent.webidl' in path:
         return False
+    if 'tools/ts/' in path:
+        return False
     return True
 
 def modify_file_list(lines, config):

--- a/mozilla-cedar/repo_files.py
+++ b/mozilla-cedar/repo_files.py
@@ -10,7 +10,13 @@ def filter_webidl(path):
         return False
     if 'dom/webidl/MozApplicationEvent.webidl' in path:
         return False
+    if 'tools/ts/' in path:
+        return False
     return True
+
+def modify_file_list(lines, config):
+    lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    return lines
 
 def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:

--- a/mozilla-central/repo_files.py
+++ b/mozilla-central/repo_files.py
@@ -10,6 +10,8 @@ def filter_webidl(path):
         return False
     if 'dom/webidl/MozApplicationEvent.webidl' in path:
         return False
+    if 'tools/ts/' in path:
+        return False
     return True
 
 def modify_file_list(lines, config):

--- a/mozilla-cypress/repo_files.py
+++ b/mozilla-cypress/repo_files.py
@@ -3,6 +3,21 @@ def filter_ipdl(path):
         return False
     return True
 
+def filter_webidl(path):
+    if 'dom/bindings/mozwebidlcodegen/test' in path:
+        return False
+    if 'dom/bindings/test' in path:
+        return False
+    if 'dom/webidl/MozApplicationEvent.webidl' in path:
+        return False
+    if 'tools/ts/' in path:
+        return False
+    return True
+
+def modify_file_list(lines, config):
+    lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    return lines
+
 def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False

--- a/mozilla-elm/repo_files.py
+++ b/mozilla-elm/repo_files.py
@@ -10,7 +10,13 @@ def filter_webidl(path):
         return False
     if 'dom/webidl/MozApplicationEvent.webidl' in path:
         return False
+    if 'tools/ts/' in path:
+        return False
     return True
+
+def modify_file_list(lines, config):
+    lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    return lines
 
 def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:

--- a/mozilla-esr115/repo_files.py
+++ b/mozilla-esr115/repo_files.py
@@ -10,6 +10,8 @@ def filter_webidl(path):
         return False
     if 'dom/webidl/MozApplicationEvent.webidl' in path:
         return False
+    if 'tools/ts/' in path:
+        return False
     return True
 
 def modify_file_list(lines, config):

--- a/mozilla-esr128/repo_files.py
+++ b/mozilla-esr128/repo_files.py
@@ -3,6 +3,21 @@ def filter_ipdl(path):
         return False
     return True
 
+def filter_webidl(path):
+    if 'dom/bindings/mozwebidlcodegen/test' in path:
+        return False
+    if 'dom/bindings/test' in path:
+        return False
+    if 'dom/webidl/MozApplicationEvent.webidl' in path:
+        return False
+    if 'tools/ts/' in path:
+        return False
+    return True
+
+def modify_file_list(lines, config):
+    lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    return lines
+
 def filter_js(path):
     if 'js/src/tests' in path or 'jit-test' in path:
         return False

--- a/mozilla-release/repo_files.py
+++ b/mozilla-release/repo_files.py
@@ -10,6 +10,8 @@ def filter_webidl(path):
         return False
     if 'dom/webidl/MozApplicationEvent.webidl' in path:
         return False
+    if 'tools/ts/' in path:
+        return False
     return True
 
 def modify_file_list(lines, config):


### PR DESCRIPTION
This changes the m-c repo_files to ignore tools/ts added by https://bugzilla.mozilla.org/show_bug.cgi?id=1895418 which caused breakage.  This also propagates the updated repo_files to the other actively indexed m-c trees which includes propagation of the CSS2 properties which seems to be on all branches so it's okay to add.