### PR TITLE
Bug 1904670 - Do not index WebIDL in ESR115

### DIFF
--- a/mozilla-esr115/repo_files.py
+++ b/mozilla-esr115/repo_files.py
@@ -4,15 +4,7 @@ def filter_ipdl(path):
     return True
 
 def filter_webidl(path):
-    if 'dom/bindings/mozwebidlcodegen/test' in path:
-        return False
-    if 'dom/bindings/test' in path:
-        return False
-    if 'dom/webidl/MozApplicationEvent.webidl' in path:
-        return False
-    if 'tools/ts/' in path:
-        return False
-    return True
+    return False
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1904670

`WebIDL.py` is not compatible on ESR115 due to filename data representation difference,
which causes many warnings, and also it fails to find the binding C++ file.
the WebIDL indexing should be disabled on ESR115 at least for now.

Other options would be either:
  * make `webidl-analyze.py` compatible with this version, or
  * always download `WebIDL.py` from mozilla-central

but I guess we can leave it to other bug.