### PR TITLE
Bug 1904890 - Don't walk graphviz submodules.

### DIFF
--- a/config5.json
+++ b/config5.json
@@ -31,6 +31,7 @@
         "git_path": "$WORKING/graphviz/git",
         "git_blame_path": "$WORKING/graphviz/blame",
         "github_repo": "https://gitlab.com/graphviz/graphviz.git",
+        "walk_submodules": false,
         "objdir_path": "$WORKING/graphviz/objdir",
         "ignore_missing_path_prefixes": [
           "$WORKING/graphviz/objdir/conftest",

--- a/just-graphviz.json
+++ b/just-graphviz.json
@@ -1,0 +1,24 @@
+{
+    "mozsearch_path": "$MOZSEARCH_PATH",
+    "config_repo": "$CONFIG_REPO",
+    "default_tree": "graphviz",
+    "instance_type": "t3.xlarge",
+
+    "trees": {
+      "graphviz": {
+        "priority": 3,
+        "on_error": "continue",
+        "cache": "codesearch",
+        "index_path": "$WORKING/graphviz",
+        "files_path": "$WORKING/graphviz/git",
+        "git_path": "$WORKING/graphviz/git",
+        "git_blame_path": "$WORKING/graphviz/blame",
+        "github_repo": "https://gitlab.com/graphviz/graphviz/-",
+        "walk_submodules": false,
+        "objdir_path": "$WORKING/graphviz/objdir",
+        "codesearch_path": "$WORKING/graphviz/livegrep.idx",
+        "codesearch_port": 8082,
+        "scip_subtrees": {}
+      }
+    }
+  }


### PR DESCRIPTION
This also adds just-graphviz.json which matches the `make build-graphviz-repo` target I added to the Makefile a while ago that requires it but that I forgot to land.  The rationale for these files over the jq filtering approach has been that the jq approach really only works for local indexing runs right now since the indexer does not know how to perform an equivalent step, but I've often thought about adding an equivalent step.  That said, the individual files also allow us to customize the web-server instance type we use which should usually not be the same tier as if the whole config was run.