### PR TITLE
Bug 1922408 - update LLVM cmake ignore paths like webkit

### DIFF
--- a/config4.json
+++ b/config4.json
@@ -28,7 +28,7 @@
       "github_repo": "https://github.com/llvm/llvm-project",
       "objdir_path": "$WORKING/llvm/objdir",
       "ignore_missing_path_prefixes": [
-        "$WORKING/llvm/objdir/CMakeFiles/CMakeTmp/"
+        "$WORKING/llvm/objdir/CMakeFiles/CMakeScratch/"
       ],
       "codesearch_path": "$WORKING/llvm/livegrep.idx",
       "codesearch_port": 8082,


### PR DESCRIPTION
Our LLVM semantic build also uses CMake and so the change from CMakeTmp to CMakeScratch is also necessary for LLVM in config4 too.