### PR TITLE
Revert "Bug 1930345 - remove cypress from config4 but retain vcs sync"

### DIFF
--- a/config4.json
+++ b/config4.json
@@ -213,6 +213,21 @@
       "codesearch_path": "$WORKING/mozilla-cedar/livegrep.idx",
       "codesearch_port": 8094,
       "scip_subtrees": {}
+    },
+
+    "mozilla-cypress": {
+      "priority": 200,
+      "on_error": "continue",
+      "cache": "codesearch",
+      "index_path": "$WORKING/mozilla-cypress",
+      "files_path": "$WORKING/mozilla-cypress/git",
+      "git_path": "$WORKING/mozilla-cypress/git",
+      "git_blame_path": "$WORKING/mozilla-cypress/blame",
+      "hg_root": "https://hg.mozilla.org/projects/cypress",
+      "objdir_path": "$WORKING/mozilla-cypress/objdir",
+      "codesearch_path": "$WORKING/mozilla-cypress/livegrep.idx",
+      "codesearch_port": 8095,
+      "scip_subtrees": {}
     }
   }
 }

--- a/help.html
+++ b/help.html
@@ -81,6 +81,7 @@ subdirectories (i.e., <code>*</code> does not match <code>/</code>).
        <tr><td><a href="/mozilla-build/source/">mozilla-build</a></td>      <td yes></td>   <td yes></td>   <td yes></td>   <td></td>       <td></td>       <td></td>       </tr>
        <tr><td><a href="/mozilla-elm/source/">mozilla-elm</a></td>          <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-cedar/source/">mozilla-cedar</a></td>      <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
+       <tr><td><a href="/mozilla-cypress/source/">mozilla-cypress</a></td>  <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-beta/source/">mozilla-beta</a></td>        <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-release/source/">mozilla-release</a></td>  <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>
        <tr><td><a href="/mozilla-esr128/source/">mozilla-esr128</a></td>    <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   <td yes></td>   </tr>


### PR DESCRIPTION
Reverts mozsearch/mozsearch-mozilla#269

The cypress tree has artifacts again so we can re-enable it.