### PR TITLE
Bug 1900534 - Switch l10n repo to https://github.com/mozilla-l10n/firefox-l10n

### DIFF
--- a/config4.json
+++ b/config4.json
@@ -11,6 +11,8 @@
       "index_path": "$WORKING/l10n",
       "files_path": "$WORKING/l10n/git",
       "git_path": "$WORKING/l10n/git",
+      "git_blame_path": "$WORKING/l10n/blame",
+      "github_repo": "https://github.com/mozilla-l10n/firefox-l10n",
       "objdir_path": "$WORKING/l10n/objdir",
       "codesearch_path": "$WORKING/l10n/livegrep.idx",
       "codesearch_port": 8081,

--- a/l10n/setup
+++ b/l10n/setup
@@ -12,31 +12,33 @@ if [ -d "git" ]
 then
     echo "Found pre-existing l10n git folder; skipping re-download."
 else
-    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/l10n.tar
-    tar xf l10n.tar
-    rm l10n.tar
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/firefox-l10n.tar.lz4
+    lz4 -dc firefox-l10n.tar.lz4 | tar -x
+    rm firefox-l10n.tar.lz4
 fi
 popd
 
 date
 
+echo Downloading l10n blame.
+pushd $INDEX_ROOT
+if [ -d "blame" ]
+then
+    echo "Found pre-existing l10n blame folder; skipping re-download."
+else
+    wget -nv https://s3-us-west-2.amazonaws.com/searchfox.repositories/firefox-l10n-blame.tar.lz4
+    lz4 -dc firefox-l10n-blame.tar.lz4 | tar -x
+    rm firefox-l10n-blame.tar.lz4
+fi
+popd
+
 echo Updating git
 pushd $GIT_ROOT
-# pull latest subrepos. We can't just do a `git submodule update --remote`
-# because the submodules are cinnabar clones, and git doesn't like that. We
-# can't even do `git submodule foreach 'git pull'` so we have to resort to
-# looping manually like cavepeople or something.
-git config fetch.prune true
-for submod in *; do
-    pushd $submod
-    git pull || echo "WARNING: The ${submod} subrepo inside l10n-central seems to be missing!"
-    popd
-done
-# The previous step will update the submodules of this top-level synthetic superproject,
-# and now we want to commit those changes, so that the top-level superproject points
-# to the latest version of each submodule.
-git add *
-git commit --allow-empty -am "Submodule update at $(date)" --author "Searchfox Indexer <searchfox-aws@mozilla.com>"
+git pull origin main
+
 popd
+
+echo Generating blame information
+$MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT
 
 date

--- a/l10n/upload
+++ b/l10n/upload
@@ -8,19 +8,20 @@ date
 
 echo Uploading l10n
 pushd $INDEX_ROOT
-
-echo "Running maintenance on l10n submodules..."
-for submod in ./git/*; do
-    $CONFIG_REPO/shared/git-maintenance.sh "${submod}"
-done
-echo "Running maintenance on l10n supermodule..."
 $CONFIG_REPO/shared/git-maintenance.sh ./git
-echo "Maintenance complete!"
+tar cf - git | lz4 - firefox-l10n.tar.lz4
+$AWS_ROOT/upload.py $INDEX_ROOT/firefox-l10n.tar.lz4 searchfox.repositories firefox-l10n.tar.lz4
+rm firefox-l10n.tar.lz4
+popd
 
-tar cf l10n.tar git
-$AWS_ROOT/upload.py $INDEX_ROOT/l10n.tar searchfox.repositories l10n.tar
-rm l10n.tar
+date
 
+echo Uploading l10n blame
+pushd $INDEX_ROOT
+$CONFIG_REPO/shared/git-maintenance.sh ./blame
+tar cf - blame | lz4 - firefox-l10n-blame.tar.lz4
+$AWS_ROOT/upload.py $INDEX_ROOT/firefox-l10n-blame.tar.lz4 searchfox.repositories firefox-l10n-blame.tar.lz4
+rm firefox-l10n-blame.tar.lz4
 popd
 
 date


### PR DESCRIPTION
I've locally run the steps from
https://github.com/mozsearch/mozsearch/blob/master/docs/newrepo.md for https://github.com/mozilla-l10n/firefox-l10n and created firefox-l10n git and blame lz4 tarballs.  I locally have tested that this works by creating a just-l10n.json config and "build-l10n-repo" target and run with that to verify I didn't mess up anything obvious, but I won't land those changes because this is not a tree that justifies having that; we should just do the dynamic thing so we can specify a config file and a tree in that config file if we want.