### PR TITLE
Bug 1458882 - Fetch doc trees.json

### DIFF
--- a/shared/fetch-tc-artifacts.sh
+++ b/shared/fetch-tc-artifacts.sh
@@ -84,6 +84,10 @@ echo "${CURL} ${TC_REV_PREFIX}.source.manifest-upload/artifacts/public/manifests
 # patches, making stale data potentially very misleading.  See Bug 1677903 for
 # more discussion.
 echo "${CURL} ${TC_TASK}/project.relman.code-coverage.production.repo.${REVISION_TREE}.${INDEXED_HG_REV}/artifacts/public/code-coverage-report.json -o code-coverage-report.json || true" >> downloads.lst
+
+# Firefox Source Docs trees.
+echo "${CURL} ${TC_LATEST_PREFIX}.source.doc-generate/artifacts/public/trees.json -o doc-trees.json || true" >> downloads.lst
+
 for PLATFORM in linux64 macosx64 macosx64-aarch64 win64 android-armv7 android-aarch64 ios; do
     TC_PREFIX="${TC_REV_PREFIX}.firefox.${PLATFORM}-searchfox-debug/artifacts/public/build"
     # First check that the searchfox job exists for the platform and revision we want. Otherwise emit a warning and skip it. This


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1458882

the `trees.json` URL is going to be added by the bug's patch.