### PR TITLE
Bug 1942757 - Stop creating the rust-analyzed file

### DIFF
--- a/shared/process-gecko-analysis.sh
+++ b/shared/process-gecko-analysis.sh
@@ -11,10 +11,6 @@ set -o pipefail # Check all commands in a pipeline
 echo "linux64 macosx64 macosx64-aarch64 win64 android-armv7 android-aarch64 ios" | tr " " "\n" |
 parallel --halt now,fail=1 "$CONFIG_REPO/shared/process-tc-artifacts.sh {}"
 
-# the script above ran the rust analysis, so drop this hacky file to tell
-# rust-analyze.sh to not do anything.
-touch objdir/rust-analyzed
-
 # Combine the per-platform list files
 cat generated-files-*.list > generated-files.list
 cat analysis-files-*.list > analysis-files.list


### PR DESCRIPTION
This is a part of https://bugzilla.mozilla.org/show_bug.cgi?id=1942757

With the https://github.com/mozsearch/mozsearch/pull/860 patch stack, the files in objdir are all reflected to the output.
The rust-analyzed file is created there for historical reason and it's no longer necessary.