### PR TITLE
Use scip-python from PATH instead of using mise

### DIFF
--- a/mozilla-central/build
+++ b/mozilla-central/build
@@ -57,7 +57,7 @@ jo verboseOutput=false \
 
 # Absolute paths aren't treated as absolute but instead concatenated, so we need
 # to use just a filename and then move it after.
-mise exec nodejs@18 -- scip-python index --show-progress-rate-limit 0 --project-name python --output python.scip
+scip-python index --show-progress-rate-limit 0 --project-name python --output python.scip
 mv python.scip $INDEX_ROOT
 popd
 

--- a/mozsearch/build
+++ b/mozsearch/build
@@ -32,7 +32,7 @@ date
 ## Python Indexing
 
 cd $FILES_ROOT
-mise exec nodejs@18 -- scip-python index --show-progress-rate-limit 0 --project-name python --output python.scip
+scip-python index --show-progress-rate-limit 0 --project-name python --output python.scip
 mv python.scip $INDEX_ROOT
 
 date


### PR DESCRIPTION
This is the counterpart of https://github.com/mozsearch/mozsearch/commit/9ec3c6b0.