### PR TITLE
Bug 1976390 - mozsearch-tests should continue on error, not halt

### DIFF
--- a/config1.json
+++ b/config1.json
@@ -114,7 +114,7 @@
 
     "mozsearch-tests": {
       "priority": 550,
-      "on_error": "halt",
+      "on_error": "continue",
       "cache": "everything",
       "index_path": "$WORKING/mozsearch-tests",
       "files_path": "$WORKING/mozsearch-tests/files",


### PR DESCRIPTION
A rust-analyzer regression on nightly surface that we're currently set to halt, but there's no benefit to this now that we have CI.