### PR TITLE
Remove nss from config1 with the intent to add it back to config4

### DIFF
--- a/config1.json
+++ b/config1.json
@@ -96,22 +96,6 @@
       "codesearch_path": "$WORKING/mozsearch-tests/livegrep.idx",
       "codesearch_port": 8085,
       "scip_subtrees": {}
-    },
-
-    "nss": {
-      "priority": 10,
-      "on_error": "continue",
-      "cache": "codesearch",
-      "index_path": "$WORKING/nss",
-      "files_path": "$WORKING/nss/git",
-      "git_path": "$WORKING/nss/git",
-      "git_blame_path": "$WORKING/nss/blame",
-      "github_repo": "https://github.com/nss-dev/nss",
-      "hg_root": "https://hg.mozilla.org/projects/nss",
-      "objdir_path": "$WORKING/nss/dist",
-      "codesearch_path": "$WORKING/nss/livegrep.idx",
-      "codesearch_port": 8086,
-      "scip_subtrees": {}
     }
   }
 }


### PR DESCRIPTION
The nss repo lost a commit and this breaks things with our current naive `git pull`.  We should potentially just move to doing a `git fetch` followed by forcibly checking out whatever the upstream default branch's head is.  We're not particularly concerned about the nss tree jumping around.