### PR TITLE
Bug 1890435 - Correct firefox-esr115 codesearch_port copy-and-paste error

### DIFF
--- a/config2.json
+++ b/config2.json
@@ -110,7 +110,7 @@
       "wpt_root": "testing/web-platform",
       "objdir_path": "$WORKING/firefox-esr115/objdir",
       "codesearch_path": "$WORKING/firefox-esr115/livegrep.idx",
-      "codesearch_port": 8083,
+      "codesearch_port": 8085,
       "scip_subtrees": {}
     }
   }


### PR DESCRIPTION
This is a very common error to make when copying-and-pasting, and I say this based on definitely having made this error this time and before, but also from having reviewed/used various ESR patches contributed.

We already have an essential transformation step in `generate-config.sh` without which the config file will not have usable paths, and this is a situation where jq can easily help us do the numbering.  The question is then whether we remove "codesearch_port" from the authored config files or instead put "auto" in place to help make it clear what we expect to happen downstream in the file's lifecycle.