### PR TITLE
Bug 1986051 - Add CSSStyleProperties.webidl to the file list.

### DIFF
--- a/firefox-beta/repo_files.py
+++ b/firefox-beta/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/firefox-main/repo_files.py
+++ b/firefox-main/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/firefox-release/repo_files.py
+++ b/firefox-release/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/mozilla-beta/repo_files.py
+++ b/mozilla-beta/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/mozilla-cedar/repo_files.py
+++ b/mozilla-cedar/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/mozilla-central/repo_files.py
+++ b/mozilla-central/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/mozilla-cypress/repo_files.py
+++ b/mozilla-cypress/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/mozilla-elm/repo_files.py
+++ b/mozilla-elm/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):

--- a/mozilla-release/repo_files.py
+++ b/mozilla-release/repo_files.py
@@ -16,6 +16,7 @@ def filter_webidl(path):
 
 def modify_file_list(lines, config):
     lines.append(b'__GENERATED__/dom/bindings/CSS2Properties.webidl')
+    lines.append(b'__GENERATED__/dom/bindings/CSSStyleProperties.webidl')
     return lines
 
 def filter_js(path):


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1986051 and https://github.com/mozsearch/mozsearch/pull/897

This does:
  * add `CSSStyleProperties.webidl`, which is the new filename of `CSS2Properties.webidl`, to the file list, for each non-esr branches

This can be removed once all non-esr branches receive the [bug 1919582](https://bugzilla.mozilla.org/show_bug.cgi?id=1919582) changes.