### PR TITLE
Bug 2025317 - Use m6id.2xlarge for config1.json.

### DIFF
--- a/config1.json
+++ b/config1.json
@@ -2,7 +2,7 @@
   "mozsearch_path": "$MOZSEARCH_PATH",
   "config_repo": "$CONFIG_REPO",
   "default_tree": "firefox-main",
-  "instance_type": "t3.2xlarge",
+  "instance_type": "m6id.2xlarge",
 
   "trees": {
     "firefox-main": {


### PR DESCRIPTION
for [bug 2025317](https://bugzilla.mozilla.org/show_bug.cgi?id=2025317)
depends https://github.com/mozsearch/mozsearch/pull/1074

This does:
  * Let config1 use `m6id.2xlarge` instance type, which has 474GB local NVMe
  * Combined with https://github.com/mozsearch/mozsearch/pull/1074, the release1 will store the /index into the local NVMe, which will help the codesearch performance