### PR TITLE
Bug 2013948 - Use codedov2git_gcloud to download historical coverage

### DIFF
--- a/firefox-main/setup
+++ b/firefox-main/setup
@@ -21,28 +21,18 @@ $CONFIG_REPO/firefox-shared/checkout-gecko-repos.sh $BUILD_REVISION_TREE "main" 
 $CONFIG_REPO/firefox-shared/fetch-tc-artifacts.sh $BUILD_REVISION_TREE $INDEXED_HG_REV "$PREEXISTING_HG_REV"
 
 echo "Performing setup::codecov2git step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
-mkdir -p "$COVERAGE_ROOT"
+if [ ! -d "$COVERAGE_ROOT" ]; then
+    # Can't directly clone https://searchfox.repositories.s3.amazonaws.com/firefox-main-coverage.bundle because the bucket has got a . in its name.
+    if [[ ! -f "firefox-main-coverage.bundle" ]]; then
+        aws s3 cp s3://searchfox.repositories/firefox-main-coverage.bundle . --no-sign-request
+    fi
+    git clone --mirror firefox-main-coverage.bundle "$COVERAGE_ROOT"
+    rm firefox-main-coverage.bundle
+fi
 
-# Fetch the mozilla-central pushes for the last week, with 1 line per push and format <hg hash>:<git hash>
-RECENT_PUSHES=$(curl "https://hg-edge.mozilla.org/mozilla-central/json-pushes?version=2&tipsonly=1&startdate=-1w" | jq -r '.pushes | to_entries | sort_by(.key) | [.[] | .value | {hg: .changesets[0], git: .git_changesets[0]}] | .[] | .hg + ":" + .git')
-COVERAGE_BUCKET_ROOT="https://storage.googleapis.com/download/storage/v1/b/relman-code-coverage-prod/o"
-
-for PUSH in $RECENT_PUSHES; do
-    IFS=':' read -ra SPLIT <<< "$PUSH"
-    COVERAGE_HG_REV=${SPLIT[0]}
-    COVERAGE_GIT_REV=${SPLIT[1]}
-    COVERAGE_INDEX=project.relman.code-coverage.production.repo.${BUILD_REVISION_TREE}.${COVERAGE_HG_REV}
-
-    CURL="curl -SsfL --compressed"
-    # First try downloading from the bucket as that's faster, or try the taskcluster API as that's available faster, otherwise bail-out for this push
-    ${CURL} "${COVERAGE_BUCKET_ROOT}/${BUILD_REVISION_TREE}%2F${COVERAGE_HG_REV}%2Fall:all.json.zstd?alt=media" | unzstd > code-coverage-report.json \
-        || ${CURL} ${TC_INDEX_API_URL}/${COVERAGE_INDEX}/artifacts/public/code-coverage-report.json > code-coverage-report.json \
-        || continue
-
-    COVERAGE_DATE="$(git -C "$GIT_ROOT" show --no-patch --format=%cI "$COVERAGE_GIT_REV")"
-    codecov2git --report code-coverage-report.json --output-repo "$COVERAGE_ROOT" --commit "$COVERAGE_GIT_REV" --date "$COVERAGE_DATE"
-    rm code-coverage-report.json
-done
+COVERAGE_SINCE=$(date --iso-8601=seconds --date='last month')
+COVERAGE_BRANCH="all/all"
+codecov2git_gcloud --firefox-repo "$GIT_ROOT" --output-repo "$COVERAGE_ROOT" --since "$COVERAGE_SINCE" --branch "$COVERAGE_BRANCH"
 
 # Note that only $SHARED_BARE_GIT_ROOT diverges from the worktree $GIT_ROOT.
 # We use these paths for clarity/consistency that we're working in bare-repo space.

--- a/firefox-main/upload
+++ b/firefox-main/upload
@@ -42,3 +42,13 @@ tar cf - blame | lz4 -f - firefox-shared-blame.tar.lz4
 aws s3 cp firefox-shared-blame.tar.lz4 s3://searchfox.repositories/firefox-shared-blame.tar.lz4 --acl public-read
 rm firefox-shared-blame.tar.lz4
 popd
+
+echo "Performing upload::coverage step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
+echo 'Uploading "coverage" bundle: firefox-main-coverage.bundle'
+pushd $SHARED_ROOT
+git -C "$COVERAGE_ROOT" bundle create "$(pwd)/firefox-main-coverage.bundle" --all
+# Note that we're using the "aws" command instead of $AWS_ROOT/upload.py for
+# parallelism reasons.
+aws s3 cp firefox-main-coverage.bundle s3://searchfox.repositories/firefox-main-coverage.bundle --acl public-read
+rm firefox-main-coverage.bundle
+popd


### PR DESCRIPTION
Depends on https://github.com/mozsearch/mozsearch/pull/1068

This downloads `firefox-main-coverage.bundle` from AWS S3 (which currently has 1 year worth of coverage) and adds the last month of coverage if missing before re-uploading.