### PR TITLE
Bug 1923545 - enable VERBOSE=1 for wubkat builds to get more info

### DIFF
--- a/wubkat/build
+++ b/wubkat/build
@@ -60,7 +60,7 @@ cmake $FILES_ROOT \
 
 echo "Performing build::make step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
 
-make -j$(nproc)
+make -j$(nproc) VERBOSE=1
 cd -
 
 echo "Performing build::remove-duplicate-headers step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"


### PR DESCRIPTION
Note that when this bug was initially filed I had manually tried to run with VERBOSE=1 and there was no obvious smoking gun, but it's possible the logging situation may have improved in the 2 years since then and/or an LLM might be able to scrape something useful out of the log.