### PR TITLE
Bug 2042171 - Use unzstd or gunzip instead of bsdtar for single files.

### DIFF
--- a/firefox-shared/fetch-tc-artifacts.sh
+++ b/firefox-shared/fetch-tc-artifacts.sh
@@ -46,9 +46,10 @@ download_artifact() {
     tmpfile=$(mktemp)
     trap "rm -f '${tmpfile}'" RETURN
 
-    if ${CURL} "${url_base}.zst" -o "${tmpfile}" ||
-       ${CURL} "${url_base}.gz"  -o "${tmpfile}"; then
-        bsdtar -xOf "${tmpfile}" > "${outfile}" || { warn "Failed to decompress ${url_base}"; return 2; }
+    if ${CURL} "${url_base}.zst" -o "${tmpfile}"; then
+        unzstd < "${tmpfile}" > "${outfile}" || { warn "Failed to decompress ${url_base}"; return 2; }
+    elif ${CURL} "${url_base}.gz"  -o "${tmpfile}"; then
+        gunzip < "${tmpfile}" > "${outfile}" || { warn "Failed to decompress ${url_base}"; return 2; }
     elif ${CURL} "${url_base}" -o "${tmpfile}"; then
         mv "${tmpfile}" "${outfile}"
     else


### PR DESCRIPTION
bsdtar only handles (optionally compressed) archives, not single compressed files.

Fixup for https://github.com/mozsearch/mozsearch-mozilla/pull/318