### PR TITLE
Bug 2046479 - Part 2: Fix the tree-list order for esr153.

### DIFF
--- a/config2.json
+++ b/config2.json
@@ -75,7 +75,7 @@
       "codesearch_port": 8083,
       "scip_subtrees": {},
       "group": "Firefox",
-      "group_order": 17,
+      "group_order": 16,
       "help_indexed_langs": ["js", "idl", "cpp", "rs", "java"]
     },
 


### PR DESCRIPTION
followup for [bug 2046479](https://bugzilla.mozilla.org/show_bug.cgi?id=2046479)

This does:
  * Fix the order inside the Firefox group, so that esr153 is shown above esr140