### PR TITLE
firefox-main: restore TRYPUSH_REV feature

### DIFF
--- a/firefox-main/setup
+++ b/firefox-main/setup
@@ -9,6 +9,17 @@ set -o pipefail # Check all commands in a pipeline
 BUILD_REVISION_TREE=mozilla-central
 BUILD_REVISION_ID=latest
 
+# Set TRYPUSH_REV in the environment to e.g. ee64db93dcc149da9313460317257b8c42eec5b2
+# or whatever to test a try revision. It needs to be the full rev hash, so that we can
+# find the artifacts in taskcluster.
+TRYPUSH_REV=${TRYPUSH_REV:-}
+if [ -n "$TRYPUSH_REV" ]; then
+    echo "Performing setup::use-trypush step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
+
+    BUILD_REVISION_TREE=try
+    BUILD_REVISION_ID="revision.${TRYPUSH_REV}"
+fi
+
 TC_ROOT_URL=https://firefox-ci-tc.services.mozilla.com
 TC_INDEX_API_URL=${TC_ROOT_URL}/api/index/v1/task
 


### PR DESCRIPTION
Partially reverts 652ce702 which removed the TRYPUSH_REV feature by mistake.