### PR TITLE
Build wubkat with Ninja

### DIFF
--- a/wubkat/build
+++ b/wubkat/build
@@ -41,6 +41,7 @@ CXX=${CXX:0:7}
 echo "Performing build::cmake step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
 
 cmake $FILES_ROOT \
+    -GNinja \
     -DCMAKE_C_COMPILER="$CC" \
     -DCMAKE_CXX_COMPILER="$CXX" \
     -DCMAKE_C_FLAGS="$C_FLAGS" \
@@ -58,9 +59,9 @@ cmake $FILES_ROOT \
     -DENABLE_DOCUMENTATION=OFF \
     -DENABLE_INTROSPECTION=OFF
 
-echo "Performing build::make step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
+echo "Performing build::ninja step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
 
-make -j$(nproc) VERBOSE=1
+cmake --build . -v
 cd -
 
 echo "Performing build::remove-duplicate-headers step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"


### PR DESCRIPTION
Aims to fix this error:
```
CMake Error at Source/cmake/WebKitCommon.cmake:111 (message):
  The GTK port requires the Ninja generator, but this build directory was
  configured with the "Unix Makefiles" generator.

  Re-run CMake with -GNinja or export CMAKE_GENERATOR=Ninja
```