### PR TITLE
Update the wubkat last-good-build check

### DIFF
--- a/wubkat/last-successful-build-to-git-commit.sh
+++ b/wubkat/last-successful-build-to-git-commit.sh
@@ -1,17 +1,35 @@
 #!/usr/bin/env bash
+
 # This is evolved from dpino's script from:
 # https://gist.github.com/dpino/b324320652bb8b758acde123f9a3dbdc
 # with the evolution process happening there, which you can read if you like!
 # Many thanks to dpino!
 
-# Debugging this?  Uncomment the following to see the commands as they run!
+# Debugging this? Uncomment the following to see the commands as they run!
 #set -x
 
-BUILDER_NAME=${1:-GTK-Linux-64-bit-Release-Ubuntu-2204-Build}
-BUILD_INFO=$(curl "https://build.webkit.org/api/v2/builders/$BUILDER_NAME/builds?order=-number&limit=1&complete=true&state_string=build%20successful" 2>/dev/null)
-NUMBER=$(jq -Mr '.builds[0].number' <<< "$BUILD_INFO")
-BUILDER_ID=$(jq -Mr '.builds[0].builderid' <<< "$BUILD_INFO")
-CHANGES_INFO=$(curl "https://build.webkit.org/api/v2/builders/$BUILDER_ID/builds/$NUMBER/changes" 2>/dev/null)
-BUILD_REV=$(jq -Mr '.changes[0].revision' <<< "$CHANGES_INFO")
+BUILDER_NAME=${1:-GTK-Linux-64-bit-Release-Ubuntu-LTS-Build}
+
+# Ask Buildbot for the newest build that has finished successfully:
+# - complete=true excludes builds that are still running.
+# - results=0 selects successful builds.  Buildbot uses numeric result codes;
+#   I've manually verified that a failed build had results=2.
+# - property=got_revision asks Buildbot to include the got_revision property
+#   in the response, which tells us the exact source revision that was checked
+#   out for the build.
+#
+# curl flags:
+# - -f / --fail: return a non-zero exit status for HTTP error responses.
+# - -s / --silent: suppress the progress meter and normal curl diagnostics.
+# - -S / --show-error: when used with --silent, still print errors if curl
+#   itself fails.
+BUILD_INFO=$(
+    curl -fsS \
+        "https://build.webkit.org/api/v2/builders/$BUILDER_NAME/builds?order=-number&limit=1&complete=true&results=0&property=got_revision"
+)
+
+BUILD_REV=$(
+    jq -er '.builds[0].properties.got_revision[0]' <<< "$BUILD_INFO"
+)
 
 echo "$BUILD_REV"


### PR DESCRIPTION
An indexing run just returned a transient null value for this and while looking into it I realized we should probably change back to `GTK-Linux-64-bit-Release-Ubuntu-LTS-Build` since while there was a good reason to use the 22.04 builder last time (the LTS builds were very stale), 22.04 is definitely no longer what we are using and the LTS builds seem to run and build correctly in a reliable fashion.

I also cleaned the script up a little to hopefully/potentially be more reliable, so I'm going to land that and then retrigger again.