### PR TITLE
Update wubkat dependencies and installation method

### DIFF
--- a/wubkat/setup
+++ b/wubkat/setup
@@ -67,16 +67,11 @@ echo Installing/updating system build dependencies
 # Update the apt index
 sudo apt-get update
 
-# gtk/install-dependencies below will install a bunch of stuff, but it seems like
-# it maybe missed these things I've added after flatpak, but they may also be
-# transitive deps of some of the below.  (And now with the return to
-# install-dependencies with explicit 22.04 these may not be needed at all, but
-# we'll see.)
-sudo apt-get install -y libcairo-dev libharfbuzz-dev gi-docgen
-
 echo "Performing setup::install-dependencies step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"
 
-# Support for 22.04 seems to have been officially added in
-# https://searchfox.org/wubkat/commit/aa960b1a0c7b980efdbc66718239a449b5966a0c
-# so we're now using it directly again.
-sudo $FILES_ROOT/Tools/gtk/install-dependencies
+# For some reasons xdg-dbus-proxy is not in the upstream package list but is
+# explicitly depended upon by the configure process.  We also added libcairo-dev
+# at some point and there is no harm in still installing it.
+sudo "$FILES_ROOT/Tools/gtk/install-dependencies" \
+    xdg-dbus-proxy \
+    libcairo-dev


### PR DESCRIPTION
xdg-dbus-proxy is an explicit configure dependency but not in the upstream package lists.

The install-dependencies script from upstream can take a list of packages and libharfbuzz-dev and gi-docgen are already in its package list so we can remove them.